### PR TITLE
feat(tools): fs + shell tools

### DIFF
--- a/orchestrator/config/settings.py
+++ b/orchestrator/config/settings.py
@@ -11,12 +11,15 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 __all__ = [
     "DEFAULT_SETTINGS_PATH",
+    "FsToolSettings",
     "LoggingSettings",
     "OllamaSettings",
     "RamSettings",
     "SchedulerSettings",
     "Settings",
     "SettingsError",
+    "ShellToolSettings",
+    "ToolsSettings",
     "load_settings",
 ]
 
@@ -70,11 +73,42 @@ class LoggingSettings(BaseModel):
         return up
 
 
+class FsToolSettings(BaseModel):
+    workspace_root: str = str(Path.home() / "orchestrator-workspace")
+
+
+class ShellToolSettings(BaseModel):
+    allow: list[str] = Field(default_factory=list)
+    deny: list[str] = Field(
+        default_factory=lambda: [
+            "rm",
+            "rmdir",
+            "sudo",
+            "su",
+            "mv",
+            "dd",
+            "mkfs",
+            "shutdown",
+            "reboot",
+            "kill",
+            "killall",
+            "chown",
+            "chmod",
+        ]
+    )
+
+
+class ToolsSettings(BaseModel):
+    fs: FsToolSettings = Field(default_factory=FsToolSettings)
+    shell: ShellToolSettings = Field(default_factory=ShellToolSettings)
+
+
 class Settings(BaseModel):
     ram: RamSettings = Field(default_factory=RamSettings)
     scheduler: SchedulerSettings = Field(default_factory=SchedulerSettings)
     ollama: OllamaSettings = Field(default_factory=OllamaSettings)
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
+    tools: ToolsSettings = Field(default_factory=ToolsSettings)
 
 
 def _read_toml(path: Path) -> dict[str, Any]:

--- a/orchestrator/config/settings.toml
+++ b/orchestrator/config/settings.toml
@@ -17,3 +17,13 @@ request_timeout_seconds = 120
 [logging]
 level = "INFO"
 json = false
+
+[tools.fs]
+# Sandbox root for every filesystem tool. Override with
+# ORCHESTRATOR__TOOLS__FS__WORKSPACE_ROOT.
+workspace_root = "~/orchestrator-workspace"
+
+[tools.shell]
+# Empty allow-list means "permit anything not denied". Populate to harden.
+allow = []
+deny = ["rm", "rmdir", "sudo", "su", "mv", "dd", "mkfs", "shutdown", "reboot", "kill", "killall", "chown", "chmod"]

--- a/orchestrator/tools/__init__.py
+++ b/orchestrator/tools/__init__.py
@@ -1,1 +1,17 @@
 """Tool implementations callable by the orchestrator."""
+
+from ._sandbox import WorkspaceEscapeError, resolve_in_workspace
+from .fs import delete_file, list_dir, read_file, write_file
+from .shell import CommandResult, DeniedCommandError, run_command
+
+__all__ = [
+    "CommandResult",
+    "DeniedCommandError",
+    "WorkspaceEscapeError",
+    "delete_file",
+    "list_dir",
+    "read_file",
+    "resolve_in_workspace",
+    "run_command",
+    "write_file",
+]

--- a/orchestrator/tools/_sandbox.py
+++ b/orchestrator/tools/_sandbox.py
@@ -1,0 +1,53 @@
+"""Shared sandbox helpers for tool implementations.
+
+Every filesystem-touching tool resolves user-supplied paths through
+:func:`resolve_in_workspace` so that traversal (``../../etc/passwd``) and
+symlink-escape attacks are rejected before any I/O happens.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["WorkspaceEscapeError", "resolve_in_workspace"]
+
+
+class WorkspaceEscapeError(PermissionError):
+    """Raised when a path resolves to a location outside the workspace root."""
+
+
+def _is_within(child: Path, root: Path) -> bool:
+    try:
+        child.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def resolve_in_workspace(path: str | Path, root: str | Path) -> Path:
+    """Resolve ``path`` and ensure it lives inside ``root``.
+
+    The returned path is fully resolved (symlinks followed) so callers receive
+    a canonical location safe to hand to :mod:`os` / :mod:`pathlib`.
+
+    Args:
+        path: User-supplied path; may be relative (resolved against ``root``)
+            or absolute.
+        root: Workspace root. Must exist on disk so that :meth:`Path.resolve`
+            can canonicalise it.
+
+    Raises:
+        WorkspaceEscapeError: If the resolved path is not equal to or a
+            descendant of the resolved ``root`` -- including the case where a
+            symlink target lies outside the workspace.
+    """
+    root_resolved = Path(root).expanduser().resolve(strict=False)
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root_resolved / candidate
+    resolved = candidate.resolve(strict=False)
+    if resolved != root_resolved and not _is_within(resolved, root_resolved):
+        raise WorkspaceEscapeError(
+            f"Path {path!r} resolves to {resolved!s} which is outside workspace {root_resolved!s}"
+        )
+    return resolved

--- a/orchestrator/tools/fs.py
+++ b/orchestrator/tools/fs.py
@@ -1,0 +1,68 @@
+"""Sandboxed filesystem tool.
+
+All operations resolve against ``settings.tools.fs.workspace_root`` and refuse
+any path that escapes the workspace (including via symlinks).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestrator.config.settings import Settings, load_settings
+
+from ._sandbox import WorkspaceEscapeError, resolve_in_workspace
+
+__all__ = [
+    "WorkspaceEscapeError",
+    "delete_file",
+    "list_dir",
+    "read_file",
+    "write_file",
+]
+
+
+def _workspace_root(settings: Settings | None) -> Path:
+    s = settings if settings is not None else load_settings()
+    return Path(s.tools.fs.workspace_root).expanduser().resolve(strict=False)
+
+
+def read_file(path: str | Path, *, settings: Settings | None = None) -> str:
+    """Return the UTF-8 contents of ``path`` inside the workspace."""
+    root = _workspace_root(settings)
+    target = resolve_in_workspace(path, root)
+    if not target.is_file():
+        raise FileNotFoundError(f"No such file: {target!s}")
+    return target.read_text(encoding="utf-8")
+
+
+def write_file(path: str | Path, content: str, *, settings: Settings | None = None) -> None:
+    """Write ``content`` (UTF-8) to ``path`` inside the workspace.
+
+    Parent directories are created as needed; existing files are overwritten.
+    """
+    root = _workspace_root(settings)
+    target = resolve_in_workspace(path, root)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+
+def list_dir(path: str | Path, *, settings: Settings | None = None) -> list[str]:
+    """Return a sorted list of entry names directly inside ``path``."""
+    root = _workspace_root(settings)
+    target = resolve_in_workspace(path, root)
+    if not target.is_dir():
+        raise NotADirectoryError(f"Not a directory: {target!s}")
+    return sorted(p.name for p in target.iterdir())
+
+
+def delete_file(path: str | Path, *, settings: Settings | None = None) -> None:
+    """Delete the file at ``path`` inside the workspace."""
+    root = _workspace_root(settings)
+    target = resolve_in_workspace(path, root)
+    if target == root:
+        raise WorkspaceEscapeError("Refusing to delete workspace root")
+    if not target.exists():
+        raise FileNotFoundError(f"No such file: {target!s}")
+    if target.is_dir():
+        raise IsADirectoryError(f"Refusing to delete directory via delete_file: {target!s}")
+    target.unlink()

--- a/orchestrator/tools/shell.py
+++ b/orchestrator/tools/shell.py
@@ -1,0 +1,170 @@
+"""Sandboxed shell tool.
+
+Executes external commands in list form (``shell=False``) constrained to the
+configured workspace root, with allow/deny lists, output size caps, and a
+hard timeout that kills the process group.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from orchestrator.config.settings import Settings, load_settings
+
+from ._sandbox import WorkspaceEscapeError, resolve_in_workspace
+
+__all__ = [
+    "CommandResult",
+    "DeniedCommandError",
+    "WorkspaceEscapeError",
+    "run_command",
+]
+
+MAX_OUTPUT_BYTES = 1_048_576  # 1 MiB cap per stream
+
+
+class DeniedCommandError(PermissionError):
+    """Raised when a command is rejected by allow/deny policy."""
+
+
+class CommandResult(BaseModel):
+    """Outcome of a single :func:`run_command` invocation."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int = Field(ge=0)
+    timed_out: bool = False
+
+
+def _executable_basename(arg: str) -> str:
+    name = Path(arg).name
+    # Strip Windows-style extensions so allow/deny lists stay portable.
+    for ext in (".exe", ".bat", ".cmd", ".ps1", ".com"):
+        if name.lower().endswith(ext):
+            name = name[: -len(ext)]
+            break
+    return name
+
+
+def _check_policy(cmd: list[str], settings: Settings) -> None:
+    if not cmd:
+        raise ValueError("cmd must be a non-empty list of strings")
+    if not all(isinstance(part, str) for part in cmd):
+        raise TypeError("cmd must contain only str entries")
+    exe = _executable_basename(cmd[0])
+    deny = {d.lower() for d in settings.tools.shell.deny}
+    allow = {a.lower() for a in settings.tools.shell.allow}
+    if exe.lower() in deny:
+        raise DeniedCommandError(f"Command {exe!r} is in deny-list")
+    if allow and exe.lower() not in allow:
+        raise DeniedCommandError(f"Command {exe!r} is not in allow-list")
+
+
+def _truncate(buf: bytes) -> str:
+    if len(buf) > MAX_OUTPUT_BYTES:
+        buf = buf[:MAX_OUTPUT_BYTES] + b"\n[truncated]\n"
+    return buf.decode("utf-8", errors="replace")
+
+
+def _kill(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        else:
+            proc.kill()
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+
+def run_command(
+    cmd: list[str],
+    timeout: float = 30,
+    cwd: str | None = None,
+    *,
+    settings: Settings | None = None,
+) -> CommandResult:
+    """Execute ``cmd`` and return a :class:`CommandResult`.
+
+    Args:
+        cmd: Argv list (``shell=False`` is enforced).
+        timeout: Seconds before the process group is killed.
+        cwd: Working directory; resolved against and constrained to
+            ``settings.tools.fs.workspace_root``. Defaults to the workspace
+            root when ``None``.
+        settings: Optional pre-loaded settings (mainly for testing).
+
+    Raises:
+        DeniedCommandError: Command rejected by allow/deny policy.
+        WorkspaceEscapeError: ``cwd`` resolves outside the workspace root.
+        ValueError: ``cmd`` is empty or ``timeout`` is non-positive.
+    """
+    if timeout <= 0:
+        raise ValueError("timeout must be > 0")
+
+    s = settings if settings is not None else load_settings()
+    _check_policy(cmd, s)
+
+    workspace = Path(s.tools.fs.workspace_root).expanduser().resolve(strict=False)
+    cwd_path = resolve_in_workspace(cwd if cwd is not None else workspace, workspace)
+    if not cwd_path.is_dir():
+        raise NotADirectoryError(f"cwd is not a directory: {cwd_path!s}")
+
+    popen_kwargs: dict[str, object] = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "cwd": str(cwd_path),
+        "shell": False,
+    }
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+    else:
+        popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+
+    start = time.monotonic()
+    timed_out = False
+    try:
+        proc = subprocess.Popen(cmd, **popen_kwargs)  # type: ignore[arg-type]
+    except FileNotFoundError as exc:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return CommandResult(
+            exit_code=127,
+            stdout="",
+            stderr=f"executable not found: {exc}",
+            duration_ms=duration_ms,
+            timed_out=False,
+        )
+
+    try:
+        stdout_b, stderr_b = proc.communicate(timeout=timeout)
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _kill(proc)
+        try:
+            stdout_b, stderr_b = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            stdout_b, stderr_b = b"", b""
+        exit_code = -1
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    return CommandResult(
+        exit_code=exit_code,
+        stdout=_truncate(stdout_b or b""),
+        stderr=_truncate(stderr_b or b""),
+        duration_ms=duration_ms,
+        timed_out=timed_out,
+    )
+
+
+# Re-export for callers that want the executable used to launch Python tests.
+PYTHON_EXECUTABLE = sys.executable

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for orchestrator.tools."""

--- a/tests/tools/test_fs.py
+++ b/tests/tools/test_fs.py
@@ -1,0 +1,110 @@
+"""Tests for orchestrator.tools.fs."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from orchestrator.config.settings import Settings
+from orchestrator.tools import fs
+from orchestrator.tools._sandbox import WorkspaceEscapeError
+
+
+def _settings(root: Path) -> Settings:
+    return Settings.model_validate({"tools": {"fs": {"workspace_root": str(root)}}})
+
+
+def test_write_then_read_roundtrip(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    fs.write_file("hello.txt", "hi there", settings=s)
+    assert fs.read_file("hello.txt", settings=s) == "hi there"
+
+
+def test_write_creates_parent_dirs(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    fs.write_file("a/b/c/file.txt", "deep", settings=s)
+    assert (tmp_path / "a" / "b" / "c" / "file.txt").read_text(encoding="utf-8") == "deep"
+
+
+def test_list_dir_returns_sorted_names(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    fs.write_file("b.txt", "", settings=s)
+    fs.write_file("a.txt", "", settings=s)
+    fs.write_file("sub/inner.txt", "", settings=s)
+    assert fs.list_dir(".", settings=s) == ["a.txt", "b.txt", "sub"]
+
+
+def test_traversal_is_rejected(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    with pytest.raises(WorkspaceEscapeError):
+        fs.read_file("../../../etc/passwd", settings=s)
+
+
+def test_absolute_outside_workspace_rejected(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    outside = tmp_path.parent / "outside.txt"
+    outside.write_text("nope", encoding="utf-8")
+    with pytest.raises(WorkspaceEscapeError):
+        fs.read_file(str(outside), settings=s)
+
+
+def test_write_outside_workspace_rejected(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    target = tmp_path.parent / "evil.txt"
+    with pytest.raises(WorkspaceEscapeError):
+        fs.write_file(str(target), "x", settings=s)
+    assert not target.exists()
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win") and sys.version_info < (3, 12),
+    reason="symlink creation requires admin/dev-mode on older Windows",
+)
+def test_symlink_escape_rejected(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    outside = tmp_path.parent / "outside_target"
+    outside.mkdir(exist_ok=True)
+    (outside / "secret.txt").write_text("classified", encoding="utf-8")
+    link = tmp_path / "escape"
+    try:
+        os.symlink(outside, link, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported in this environment")
+    with pytest.raises(WorkspaceEscapeError):
+        fs.read_file("escape/secret.txt", settings=s)
+
+
+def test_read_missing_file(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        fs.read_file("nope.txt", settings=s)
+
+
+def test_delete_file(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    fs.write_file("gone.txt", "bye", settings=s)
+    fs.delete_file("gone.txt", settings=s)
+    assert not (tmp_path / "gone.txt").exists()
+
+
+def test_delete_missing_file_raises(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        fs.delete_file("ghost.txt", settings=s)
+
+
+def test_delete_directory_refused(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    (tmp_path / "d").mkdir()
+    with pytest.raises(IsADirectoryError):
+        fs.delete_file("d", settings=s)
+
+
+def test_list_dir_on_file_raises(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    fs.write_file("f.txt", "x", settings=s)
+    with pytest.raises(NotADirectoryError):
+        fs.list_dir("f.txt", settings=s)

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -1,0 +1,136 @@
+"""Tests for orchestrator.tools.shell."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from orchestrator.config.settings import Settings
+from orchestrator.tools._sandbox import WorkspaceEscapeError
+from orchestrator.tools.shell import CommandResult, DeniedCommandError, run_command
+
+PY = sys.executable
+
+
+def _settings(
+    root: Path,
+    *,
+    allow: list[str] | None = None,
+    deny: list[str] | None = None,
+) -> Settings:
+    return Settings.model_validate(
+        {
+            "tools": {
+                "fs": {"workspace_root": str(root)},
+                "shell": {
+                    "allow": allow if allow is not None else [],
+                    "deny": deny if deny is not None else ["rm", "sudo", "mv", "dd"],
+                },
+            }
+        }
+    )
+
+
+def test_allowed_command_success(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    res = run_command([PY, "-c", "print('ok')"], settings=s)
+    assert isinstance(res, CommandResult)
+    assert res.exit_code == 0
+    assert res.stdout.strip() == "ok"
+    assert res.stderr == ""
+    assert res.timed_out is False
+    assert res.duration_ms >= 0
+
+
+def test_non_zero_exit_captured(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    res = run_command(
+        [PY, "-c", "import sys; sys.stderr.write('boom'); sys.exit(3)"],
+        settings=s,
+    )
+    assert res.exit_code == 3
+    assert "boom" in res.stderr
+    assert res.timed_out is False
+
+
+def test_denied_command_rejected(tmp_path: Path) -> None:
+    s = _settings(tmp_path, deny=["rm", "python", "python3", "python.exe"])
+    with pytest.raises(DeniedCommandError):
+        run_command([PY, "-c", "print(1)"], settings=s)
+
+
+def test_allow_list_excludes_unlisted(tmp_path: Path) -> None:
+    s = _settings(tmp_path, allow=["echo"])
+    with pytest.raises(DeniedCommandError):
+        run_command([PY, "-c", "print(1)"], settings=s)
+
+
+def test_deny_overrides_allow(tmp_path: Path) -> None:
+    exe = Path(PY).name
+    base = exe.rsplit(".", 1)[0] if "." in exe else exe
+    s = _settings(tmp_path, allow=[base], deny=[base])
+    with pytest.raises(DeniedCommandError):
+        run_command([PY, "-c", "print(1)"], settings=s)
+
+
+def test_timeout_kills_process(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    res = run_command(
+        [PY, "-c", "import time; time.sleep(30)"],
+        timeout=0.5,
+        settings=s,
+    )
+    assert res.timed_out is True
+    assert res.exit_code == -1
+    assert res.duration_ms < 10_000
+
+
+def test_cwd_defaults_to_workspace_root(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    res = run_command(
+        [PY, "-c", "import os; print(os.getcwd())"],
+        settings=s,
+    )
+    assert res.exit_code == 0
+    assert Path(res.stdout.strip()).resolve() == tmp_path.resolve()
+
+
+def test_cwd_inside_workspace_ok(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    res = run_command(
+        [PY, "-c", "import os; print(os.getcwd())"],
+        cwd=str(sub),
+        settings=s,
+    )
+    assert res.exit_code == 0
+    assert Path(res.stdout.strip()).resolve() == sub.resolve()
+
+
+def test_cwd_escape_rejected(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    with pytest.raises(WorkspaceEscapeError):
+        run_command([PY, "-c", "print(1)"], cwd=str(tmp_path.parent), settings=s)
+
+
+def test_empty_cmd_rejected(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    with pytest.raises(ValueError):
+        run_command([], settings=s)
+
+
+def test_zero_timeout_rejected(tmp_path: Path) -> None:
+    s = _settings(tmp_path)
+    with pytest.raises(ValueError):
+        run_command([PY, "-c", "pass"], timeout=0, settings=s)
+
+
+def test_missing_executable_returns_127(tmp_path: Path) -> None:
+    s = _settings(tmp_path, deny=[])
+    res = run_command(["definitely-not-a-real-binary-xyz"], settings=s)
+    assert res.exit_code == 127
+    assert res.timed_out is False
+    assert "not found" in res.stderr.lower()


### PR DESCRIPTION
Closes #26

Acceptance Criteria met — implements sandboxed `fs` and `shell` tools that resolve every path against `settings.tools.fs.workspace_root` and enforce allow/deny lists for shell commands.

## What changed
- **`orchestrator/tools/_sandbox.py`** — shared `resolve_in_workspace()` helper + `WorkspaceEscapeError`. Resolves paths (following symlinks) and rejects anything not under the workspace root.
- **`orchestrator/tools/fs.py`** — `read_file`, `write_file`, `list_dir`, `delete_file`. All paths funneled through the sandbox helper; `write_file` creates parent dirs; `delete_file` refuses directories and the workspace root itself.
- **`orchestrator/tools/shell.py`** — `run_command(cmd, timeout=30, cwd=None)` returning a Pydantic `CommandResult{exit_code, stdout, stderr, duration_ms, timed_out}`. `shell=False` (list form only); allow/deny enforced by executable basename (deny wins); `cwd` defaults to and is constrained to the workspace; timeout kills the process group (POSIX `killpg`, Windows `proc.kill()`); 1 MiB output cap per stream; UTF-8 decode with `errors="replace"`.
- **`orchestrator/config/settings.py` / `settings.toml`** — new `tools.fs.workspace_root`, `tools.shell.allow`, `tools.shell.deny` settings with sensible deny defaults (`rm`, `sudo`, `mv`, `dd`, `mkfs`, …).
- **`orchestrator/tools/__init__.py`** — re-exports public surface.
- **`tests/tools/test_fs.py`** — happy-path read/write, list, delete, plus failure modes: traversal (`../../../etc/passwd`), absolute path outside workspace, write outside workspace, symlink escape (skipped on Windows without symlink privilege), missing file, delete missing, delete directory refused, list_dir on a file.
- **`tests/tools/test_shell.py`** — allowed-command success, non-zero exit captured, denied command rejected, allow-list excludes unlisted, deny overrides allow, timeout kills, cwd defaults to workspace, cwd inside workspace OK, cwd escape rejected, empty cmd rejected, zero timeout rejected, missing executable returns 127.

## Files / paths touched
- `orchestrator/tools/__init__.py`
- `orchestrator/tools/_sandbox.py`
- `orchestrator/tools/fs.py`
- `orchestrator/tools/shell.py`
- `orchestrator/config/settings.py`
- `orchestrator/config/settings.toml`
- `tests/tools/__init__.py`
- `tests/tools/test_fs.py`
- `tests/tools/test_shell.py`

## Acceptance Criteria checklist
- [x] `fs.py` exposes `read_file`, `write_file`, `list_dir`, `delete_file`
- [x] All `fs` paths resolved with `Path.resolve(strict=False)` and rejected outside workspace root
- [x] Symlink escapes rejected with `WorkspaceEscapeError`
- [x] `shell.py` exposes `run_command` returning Pydantic `CommandResult`
- [x] Allow/deny lists from settings; deny precedence; empty allow == "anything not denied"
- [x] `cwd` defaults to and constrained to `workspace_root`; `shell=False`
- [x] Timeout kills process group; returns `timed_out=True`, `exit_code=-1`
- [x] `tests/tools/test_fs.py` covers happy path + ≥3 failure modes
- [x] `tests/tools/test_shell.py` covers allowed/denied/non-zero/timeout/cwd-escape

## Verification
- `ruff check .` — All checks passed!
- `pytest -q` — 36 passed, 1 skipped (symlink test on Windows without symlink privilege), 0 failed
