### PR TITLE
feat(tools): web fetch + search tool

### DIFF
--- a/orchestrator/config/settings.py
+++ b/orchestrator/config/settings.py
@@ -20,6 +20,7 @@ __all__ = [
     "SettingsError",
     "ShellToolSettings",
     "ToolsSettings",
+    "WebToolSettings",
     "load_settings",
 ]
 
@@ -98,9 +99,18 @@ class ShellToolSettings(BaseModel):
     )
 
 
+class WebToolSettings(BaseModel):
+    """Settings for the web fetch + search tool (`orchestrator.tools.web`)."""
+
+    user_agent: str = "orchestrator-bot/0.1 (+https://github.com/skgandikota/orchestrator)"
+    allow_private: bool = False
+    brave_api_key: str | None = None
+
+
 class ToolsSettings(BaseModel):
     fs: FsToolSettings = Field(default_factory=FsToolSettings)
     shell: ShellToolSettings = Field(default_factory=ShellToolSettings)
+    web: WebToolSettings = Field(default_factory=WebToolSettings)
 
 
 class Settings(BaseModel):

--- a/orchestrator/config/settings.toml
+++ b/orchestrator/config/settings.toml
@@ -27,3 +27,7 @@ workspace_root = "~/orchestrator-workspace"
 # Empty allow-list means "permit anything not denied". Populate to harden.
 allow = []
 deny = ["rm", "rmdir", "sudo", "su", "mv", "dd", "mkfs", "shutdown", "reboot", "kill", "killall", "chown", "chmod"]
+
+[tools.web]
+user_agent = "orchestrator-bot/0.1 (+https://github.com/skgandikota/orchestrator)"
+allow_private = false

--- a/orchestrator/tools/web.py
+++ b/orchestrator/tools/web.py
@@ -1,0 +1,336 @@
+"""Web fetch + search tool.
+
+Provides:
+
+* :func:`fetch` - stream a URL via ``httpx`` with size cap, scheme/IP
+  guards, and HTML sanitisation (``<script>``/``<style>``/comments stripped).
+* :func:`search` - run a web search via DuckDuckGo (default) or Brave.
+
+All HTTP calls flow through a shared :class:`httpx.Client` configured with the
+``tools.web.user_agent`` from settings. No live network calls are made unless
+the caller actually invokes one of these functions.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import time
+from collections.abc import Iterable
+from typing import Literal, Protocol
+from urllib.parse import urlparse
+
+import httpx
+from pydantic import BaseModel, Field
+from selectolax.parser import HTMLParser
+
+from orchestrator.config.settings import Settings, WebToolSettings, load_settings
+
+__all__ = [
+    "FetchError",
+    "FetchResult",
+    "SearchError",
+    "SearchResult",
+    "fetch",
+    "search",
+]
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+
+
+class FetchError(RuntimeError):
+    """Raised when :func:`fetch` cannot complete a request safely."""
+
+
+class SearchError(RuntimeError):
+    """Raised when :func:`search` cannot complete a query."""
+
+
+class FetchResult(BaseModel):
+    url: str
+    status: int
+    content_type: str = ""
+    text: str = ""
+    truncated: bool = False
+    elapsed_ms: int = Field(ge=0)
+
+
+class SearchResult(BaseModel):
+    title: str
+    url: str
+    snippet: str = ""
+
+
+class _SearchProvider(Protocol):
+    def search(self, query: str, limit: int) -> list[SearchResult]: ...
+
+
+def _web_settings(settings: Settings | None) -> WebToolSettings:
+    return (settings or load_settings()).tools.web
+
+
+def _validate_url(url: str, *, allow_private: bool) -> str:
+    """Validate scheme + host. Returns the parsed hostname."""
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise FetchError(f"unsupported URL scheme: {parsed.scheme!r}")
+    host = parsed.hostname
+    if not host:
+        raise FetchError(f"URL is missing a hostname: {url!r}")
+    if not allow_private and _resolves_to_private(host):
+        raise FetchError(f"refusing to fetch private/loopback host: {host!r}")
+    return host
+
+
+def _resolves_to_private(host: str) -> bool:
+    """True if any A/AAAA record for ``host`` is private/loopback/link-local."""
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise FetchError(f"DNS lookup failed for {host!r}: {exc}") from exc
+    for info in infos:
+        sockaddr = info[4]
+        addr = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            return True
+    return False
+
+
+def _strip_html(body: bytes, encoding: str | None) -> str:
+    """Return human-readable text with <script>/<style>/comments stripped."""
+    enc = encoding or "utf-8"
+    try:
+        markup = body.decode(enc, errors="replace")
+    except (LookupError, TypeError):
+        markup = body.decode("utf-8", errors="replace")
+    tree = HTMLParser(markup)
+    for sel in ("script", "style"):
+        for node in tree.css(sel):
+            node.decompose()
+    # Strip HTML comments. selectolax exposes them as nodes whose tag is
+    # "_comment"; iterate defensively in case the backend changes.
+    body_node = tree.body or tree.root
+    if body_node is not None:
+        for node in list(body_node.iter(include_text=False)):
+            if getattr(node, "tag", None) == "_comment":
+                node.decompose()
+    text = tree.text(separator=" ", strip=True) if tree.body else ""
+    return " ".join(text.split())
+
+
+def _build_client(ua: str, timeout: float) -> httpx.Client:
+    return httpx.Client(
+        follow_redirects=True,
+        timeout=timeout,
+        headers={"User-Agent": ua},
+    )
+
+
+def fetch(
+    url: str,
+    max_bytes: int = 1_000_000,
+    timeout: float = 15,
+    *,
+    settings: Settings | None = None,
+    client: httpx.Client | None = None,
+) -> FetchResult:
+    """Fetch ``url`` and return a sanitised :class:`FetchResult`.
+
+    Args:
+        url: Absolute http(s) URL.
+        max_bytes: Maximum body size (bytes). Streaming aborts once exceeded
+            and ``truncated=True`` is set on the result.
+        timeout: Per-request timeout in seconds.
+        settings: Optional pre-loaded :class:`Settings`.
+        client: Optional pre-built :class:`httpx.Client` (used by tests).
+
+    Raises:
+        FetchError: For unsupported schemes, blocked private hosts, DNS
+            failures, network errors, or timeouts.
+    """
+    if max_bytes <= 0:
+        raise FetchError("max_bytes must be positive")
+    web = _web_settings(settings)
+    _validate_url(url, allow_private=web.allow_private)
+
+    owns_client = client is None
+    http = client or _build_client(web.user_agent, timeout)
+    start = time.perf_counter()
+    try:
+        with http.stream("GET", url, timeout=timeout) as response:
+            chunks: list[bytes] = []
+            total = 0
+            truncated = False
+            for chunk in response.iter_bytes():
+                if not chunk:
+                    continue
+                remaining = max_bytes - total
+                if remaining <= 0:
+                    truncated = True
+                    break
+                if len(chunk) > remaining:
+                    chunks.append(chunk[:remaining])
+                    total += remaining
+                    truncated = True
+                    break
+                chunks.append(chunk)
+                total += len(chunk)
+            body = b"".join(chunks)
+            content_type = response.headers.get("content-type", "")
+            encoding = response.encoding
+            status = response.status_code
+    except httpx.TimeoutException as exc:
+        raise FetchError(f"timeout fetching {url!r}: {exc}") from exc
+    except httpx.HTTPError as exc:
+        raise FetchError(f"HTTP error fetching {url!r}: {exc}") from exc
+    finally:
+        if owns_client:
+            http.close()
+
+    elapsed_ms = int((time.perf_counter() - start) * 1000)
+    text = _strip_html(body, encoding) if "html" in content_type.lower() else body.decode(
+        encoding or "utf-8", errors="replace"
+    )
+    return FetchResult(
+        url=url,
+        status=status,
+        content_type=content_type,
+        text=text,
+        truncated=truncated,
+        elapsed_ms=elapsed_ms,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+class _DuckDuckGoProvider:
+    def __init__(self, user_agent: str) -> None:
+        self._user_agent = user_agent
+
+    def search(self, query: str, limit: int) -> list[SearchResult]:
+        try:
+            from duckduckgo_search import DDGS  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - optional dep guard
+            raise SearchError("duckduckgo-search is not installed") from exc
+        try:
+            with DDGS(headers={"User-Agent": self._user_agent}) as ddgs:
+                raw = list(ddgs.text(query, max_results=limit))
+        except Exception as exc:
+            raise SearchError(f"DuckDuckGo search failed: {exc}") from exc
+        return _normalise_ddg(raw, limit)
+
+
+def _normalise_ddg(rows: Iterable[dict[str, str]], limit: int) -> list[SearchResult]:
+    results: list[SearchResult] = []
+    for row in rows:
+        url = row.get("href") or row.get("url") or ""
+        if not url:
+            continue
+        results.append(
+            SearchResult(
+                title=row.get("title", ""),
+                url=url,
+                snippet=row.get("body") or row.get("snippet") or "",
+            )
+        )
+        if len(results) >= limit:
+            break
+    return results
+
+
+class _BraveProvider:
+    def __init__(self, api_key: str, user_agent: str, client: httpx.Client | None = None) -> None:
+        self._api_key = api_key
+        self._user_agent = user_agent
+        self._client = client
+
+    def search(self, query: str, limit: int) -> list[SearchResult]:
+        owns_client = self._client is None
+        http = self._client or _build_client(self._user_agent, timeout=15)
+        try:
+            response = http.get(
+                _BRAVE_ENDPOINT,
+                params={"q": query, "count": limit},
+                headers={
+                    "Accept": "application/json",
+                    "X-Subscription-Token": self._api_key,
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPError as exc:
+            raise SearchError(f"Brave search failed: {exc}") from exc
+        finally:
+            if owns_client:
+                http.close()
+
+        web_block = payload.get("web") or {}
+        rows = web_block.get("results") or []
+        results: list[SearchResult] = []
+        for row in rows[:limit]:
+            url = row.get("url") or ""
+            if not url:
+                continue
+            results.append(
+                SearchResult(
+                    title=row.get("title", ""),
+                    url=url,
+                    snippet=row.get("description") or row.get("snippet") or "",
+                )
+            )
+        return results
+
+
+def search(
+    query: str,
+    provider: Literal["duckduckgo", "brave"] = "duckduckgo",
+    limit: int = 10,
+    *,
+    settings: Settings | None = None,
+    client: httpx.Client | None = None,
+) -> list[SearchResult]:
+    """Run a web search and return up to ``limit`` :class:`SearchResult`.
+
+    Args:
+        query: Free-text search query.
+        provider: ``"duckduckgo"`` (default, no key) or ``"brave"`` (requires
+            ``settings.tools.web.brave_api_key``).
+        limit: Maximum number of results to return.
+        settings: Optional pre-loaded :class:`Settings`.
+        client: Optional pre-built :class:`httpx.Client` (Brave only; tests).
+
+    Raises:
+        SearchError: On unknown provider, missing Brave key, or upstream
+            failures.
+    """
+    if not query or not query.strip():
+        raise SearchError("query must be a non-empty string")
+    if limit <= 0:
+        raise SearchError("limit must be positive")
+    web = _web_settings(settings)
+    if provider == "duckduckgo":
+        impl: _SearchProvider = _DuckDuckGoProvider(web.user_agent)
+    elif provider == "brave":
+        if not web.brave_api_key:
+            raise SearchError(
+                "Brave provider selected but settings.tools.web.brave_api_key is unset"
+            )
+        impl = _BraveProvider(web.brave_api_key, web.user_agent, client=client)
+    else:  # pragma: no cover - guarded by Literal but defensive
+        raise SearchError(f"unknown search provider: {provider!r}")
+    return impl.search(query, limit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "psutil>=5.9",
     "pydantic>=2",
     "structlog>=24",
+    "httpx>=0.27",
+    "selectolax>=0.3.21",
+    "duckduckgo-search>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -30,6 +33,7 @@ dev = [
     "pytest-cov>=5",
     "ruff>=0.6",
     "mypy>=1.10",
+    "respx>=0.21",
 ]
 browser = [
     "playwright>=1.40",

--- a/tests/tools/test_web.py
+++ b/tests/tools/test_web.py
@@ -1,0 +1,233 @@
+"""Tests for orchestrator.tools.web."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from orchestrator.config.settings import Settings, ToolsSettings, WebToolSettings
+from orchestrator.tools import web
+from orchestrator.tools.web import (
+    FetchError,
+    FetchResult,
+    SearchError,
+    SearchResult,
+    fetch,
+    search,
+)
+
+
+def _settings(**web_overrides: Any) -> Settings:
+    return Settings(tools=ToolsSettings(web=WebToolSettings(**web_overrides)))
+
+
+@pytest.fixture(autouse=True)
+def _allow_public(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """All fetch tests run against example.com which we treat as public."""
+
+    def fake_getaddrinfo(host: str, *_a: Any, **_kw: Any) -> list[Any]:
+        return [(0, 0, 0, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(web.socket, "getaddrinfo", fake_getaddrinfo)
+    yield
+
+
+# --------------------------------------------------------------------------- fetch
+
+
+@respx.mock
+def test_fetch_happy_path_strips_html() -> None:
+    body = (
+        b"<html><head><style>.x{}</style></head>"
+        b"<body><!-- secret --><script>alert(1)</script>"
+        b"<p>Hello <b>world</b></p></body></html>"
+    )
+    respx.get("https://example.com/").mock(
+        return_value=httpx.Response(200, content=body, headers={"content-type": "text/html"})
+    )
+    result = fetch("https://example.com/", settings=_settings())
+    assert isinstance(result, FetchResult)
+    assert result.status == 200
+    assert result.truncated is False
+    assert "Hello world" in result.text
+    assert "alert" not in result.text
+    assert "secret" not in result.text
+    assert ".x{}" not in result.text
+    assert result.elapsed_ms >= 0
+
+
+@respx.mock
+def test_fetch_404_returns_status() -> None:
+    respx.get("https://example.com/missing").mock(
+        return_value=httpx.Response(404, content=b"nope", headers={"content-type": "text/plain"})
+    )
+    result = fetch("https://example.com/missing", settings=_settings())
+    assert result.status == 404
+    assert result.text == "nope"
+    assert result.truncated is False
+
+
+@respx.mock
+def test_fetch_timeout_raises() -> None:
+    respx.get("https://example.com/slow").mock(side_effect=httpx.ReadTimeout("boom"))
+    with pytest.raises(FetchError, match="timeout"):
+        fetch("https://example.com/slow", settings=_settings())
+
+
+@respx.mock
+def test_fetch_truncates_oversize_body() -> None:
+    big = b"a" * 5000
+    respx.get("https://example.com/big").mock(
+        return_value=httpx.Response(200, content=big, headers={"content-type": "text/plain"})
+    )
+    result = fetch("https://example.com/big", max_bytes=1024, settings=_settings())
+    assert result.truncated is True
+    assert len(result.text) <= 1024
+
+
+def test_fetch_rejects_non_http_scheme() -> None:
+    with pytest.raises(FetchError, match="scheme"):
+        fetch("file:///etc/passwd", settings=_settings())
+
+
+def test_fetch_rejects_private_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_getaddrinfo(host: str, *_a: Any, **_kw: Any) -> list[Any]:
+        return [(0, 0, 0, "", ("127.0.0.1", 0))]
+
+    monkeypatch.setattr(web.socket, "getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(FetchError, match="private"):
+        fetch("http://localhost/", settings=_settings(allow_private=False))
+
+
+def test_fetch_allows_private_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_getaddrinfo(host: str, *_a: Any, **_kw: Any) -> list[Any]:
+        return [(0, 0, 0, "", ("127.0.0.1", 0))]
+
+    monkeypatch.setattr(web.socket, "getaddrinfo", fake_getaddrinfo)
+    with respx.mock(assert_all_called=False) as router:
+        router.get("http://localhost/").mock(
+            return_value=httpx.Response(200, content=b"ok", headers={"content-type": "text/plain"})
+        )
+        result = fetch("http://localhost/", settings=_settings(allow_private=True))
+    assert result.status == 200
+
+
+def test_fetch_invalid_max_bytes() -> None:
+    with pytest.raises(FetchError):
+        fetch("https://example.com/", max_bytes=0, settings=_settings())
+
+
+@respx.mock
+def test_fetch_sends_user_agent() -> None:
+    route = respx.get("https://example.com/").mock(
+        return_value=httpx.Response(200, content=b"x", headers={"content-type": "text/plain"})
+    )
+    fetch("https://example.com/", settings=_settings(user_agent="ua-test/9.9"))
+    assert route.calls.last.request.headers["user-agent"] == "ua-test/9.9"
+
+
+# --------------------------------------------------------------------------- search
+
+
+def test_search_ddg_parses_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [
+        {"title": "First", "href": "https://a.example/", "body": "snip-a"},
+        {"title": "Second", "href": "https://b.example/", "body": "snip-b"},
+        {"title": "Skip-no-url", "href": "", "body": "x"},
+    ]
+
+    class FakeDDGS:
+        def __init__(self, *_a: Any, **_kw: Any) -> None: ...
+        def __enter__(self) -> FakeDDGS:
+            return self
+
+        def __exit__(self, *_a: Any) -> None: ...
+        def text(self, query: str, max_results: int) -> list[dict[str, str]]:
+            assert query == "python"
+            assert max_results == 5
+            return rows
+
+    import sys
+    import types
+
+    fake_module = types.ModuleType("duckduckgo_search")
+    fake_module.DDGS = FakeDDGS  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "duckduckgo_search", fake_module)
+
+    out = search("python", provider="duckduckgo", limit=5, settings=_settings())
+    assert [r.url for r in out] == ["https://a.example/", "https://b.example/"]
+    assert out[0].title == "First"
+    assert out[0].snippet == "snip-a"
+
+
+def test_search_ddg_upstream_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class BoomDDGS:
+        def __init__(self, *_a: Any, **_kw: Any) -> None: ...
+        def __enter__(self) -> BoomDDGS:
+            return self
+
+        def __exit__(self, *_a: Any) -> None: ...
+        def text(self, *_a: Any, **_kw: Any) -> list[dict[str, str]]:
+            raise RuntimeError("rate limited")
+
+    import sys
+    import types
+
+    fake_module = types.ModuleType("duckduckgo_search")
+    fake_module.DDGS = BoomDDGS  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "duckduckgo_search", fake_module)
+
+    with pytest.raises(SearchError, match="DuckDuckGo"):
+        search("anything", provider="duckduckgo", settings=_settings())
+
+
+def test_search_brave_without_key_raises() -> None:
+    with pytest.raises(SearchError, match="brave_api_key"):
+        search("x", provider="brave", settings=_settings(brave_api_key=None))
+
+
+@respx.mock
+def test_search_brave_happy_path() -> None:
+    payload = {
+        "web": {
+            "results": [
+                {"title": "T1", "url": "https://r1/", "description": "d1"},
+                {"title": "T2", "url": "https://r2/", "description": "d2"},
+            ]
+        }
+    }
+    route = respx.get("https://api.search.brave.com/res/v1/web/search").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    out = search(
+        "kittens",
+        provider="brave",
+        limit=2,
+        settings=_settings(brave_api_key="secret"),
+    )
+    assert isinstance(out[0], SearchResult)
+    assert [r.url for r in out] == ["https://r1/", "https://r2/"]
+    assert route.calls.last.request.headers["x-subscription-token"] == "secret"
+
+
+@respx.mock
+def test_search_brave_http_error() -> None:
+    respx.get("https://api.search.brave.com/res/v1/web/search").mock(
+        return_value=httpx.Response(429, json={"error": "rate"})
+    )
+    with pytest.raises(SearchError, match="Brave"):
+        search("x", provider="brave", settings=_settings(brave_api_key="secret"))
+
+
+def test_search_rejects_empty_query() -> None:
+    with pytest.raises(SearchError):
+        search("   ", settings=_settings())
+
+
+def test_search_rejects_bad_limit() -> None:
+    with pytest.raises(SearchError):
+        search("x", limit=0, settings=_settings())


### PR DESCRIPTION
Closes #27

Implements the Phase 4 web fetch + search tool.

## What landed
- `orchestrator/tools/web.py`
  - `fetch(url, max_bytes=1_000_000, timeout=15) -> FetchResult` that streams via `httpx`, enforces `max_bytes` (sets `truncated=True`), strips `<script>`/`<style>`/HTML comments via `selectolax`, rejects non-http(s) schemes, and rejects private/loopback/link-local hosts unless `tools.web.allow_private` is on.
  - `search(query, provider=""duckduckgo""|""brave"", limit=10) -> list[SearchResult]` with a `Provider` Protocol; DDG via `duckduckgo-search`, Brave via the official REST endpoint with `X-Subscription-Token`. Missing Brave key raises a clear `SearchError`.
  - All HTTP requests send the configured `tools.web.user_agent`.
- `orchestrator/config/settings.py` + `settings.toml` - new `tools.web` section (`user_agent`, `allow_private`, `brave_api_key`).
- `pyproject.toml` - adds `httpx`, `selectolax`, `duckduckgo-search` runtime deps and `respx` dev dep.
- `tests/tools/test_web.py` - 13 tests covering 200 happy path + HTML stripping, 404, timeout, oversize truncation, scheme rejection, private-IP rejection, `allow_private` opt-in, UA header, DDG result parsing (mocked), DDG upstream error, Brave-without-key, Brave happy path, Brave HTTP error, plus argument validation. All HTTP is mocked via `respx`; `DDGS` is stubbed via `sys.modules`; `socket.getaddrinfo` is monkey-patched. No live network.

## Verification
- `ruff check .` -> clean
- `pytest -q` -> 29 passed

Acceptance Criteria met.
