### PR TITLE
ops: enable free OSS AI code-review bot stack and gate merges on their reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,52 @@
+# https://docs.coderabbit.ai/guides/configure-coderabbit
+# CodeRabbit posts AI review comments on every PR. It does NOT gate merges -
+# only `code-reviewer-001` (our strict bot) has merge authority.
+
+language: en-US
+early_access: false
+tone_instructions: >
+  Be terse, technical, and direct. Skip praise and pleasantries. Focus on
+  correctness, security, RAM/perf footprint (this is a memory-constrained
+  orchestrator), and Python idioms. Cite line numbers. Do not repeat what
+  static analysis already catches.
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches: ["main"]
+  path_filters:
+    - "!**/*.lock"
+    - "!**/*.snap"
+    - "!**/__snapshots__/**"
+    - "!**/node_modules/**"
+    - "!**/.venv/**"
+    - "!docs/**/*.md"
+  path_instructions:
+    - path: "orchestrator/tools/**"
+      instructions: >
+        These are tool wrappers invoked by the coder model. Validate that all
+        external inputs (paths, URLs, shell args) are sanitized. Reject any
+        unbounded recursion, unscoped subprocess, or unbounded file reads.
+    - path: "orchestrator/models/**"
+      instructions: >
+        Check RAM budgeting carefully - the host has 16GB. Flag any unbounded
+        token buffers, missing model unload paths, or sync calls in async code.
+    - path: ".github/scripts/pr_reviewer.py"
+      instructions: >
+        This is the merge-gating bot. Be especially strict about auth handling,
+        secret leakage in logs, and merge race conditions.
+  tools:
+    ruff:
+      enabled: true
+    markdownlint:
+      enabled: true
+
+chat:
+  auto_reply: true

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,24 @@
+# https://developers.google.com/gemini-code-assist/docs/review-github-code
+# Gemini Code Assist for GitHub - free for public repos. Posts AI review
+# comments and a summary on every PR. Comment-only - does not gate merges.
+
+have_fun: false
+
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM   # LOW | MEDIUM | HIGH | CRITICAL
+  max_review_comments: -1               # unlimited
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+
+ignore_patterns:
+  - "**/*.lock"
+  - "**/*.snap"
+  - "**/__snapshots__/**"
+  - "**/.venv/**"
+  - "**/node_modules/**"
+  - "docs/**/*.md"
+  - ".tmp-issues/**"
+  - ".issue-bodies/**"

--- a/.github/review-bots.yml
+++ b/.github/review-bots.yml
@@ -1,0 +1,36 @@
+# Bots whose review the strict reviewer (`code-reviewer-001`) waits for
+# before approving + merging. Until every bot in `required` has posted a
+# review or substantive top-level PR comment, the strict reviewer will
+# COMMENT only ("waiting for: ...") and not merge.
+#
+# Override: apply the `bot-review-bypass` label to a PR to skip the wait
+# (use only when a configured bot is unavailable / not installed).
+#
+# Each entry must match the bot's GitHub login *exactly* (case-insensitive
+# at runtime). Use `gh api /repos/OWNER/REPO/pulls/N/reviews` after a bot
+# posts to confirm its login.
+
+required:
+  - login: copilot-pull-request-reviewer
+    name: GitHub Copilot review
+    optional: false
+  - login: coderabbitai
+    name: CodeRabbit
+    optional: true   # mark optional until installed; flip to false after install
+  - login: qodo-merge-pro-for-open-source
+    name: Qodo Merge
+    optional: true
+  - login: gemini-code-assist
+    name: Gemini Code Assist
+    optional: true
+  - login: sourcery-ai
+    name: Sourcery
+    optional: true
+
+# Bots whose latest review state must NOT be REQUEST_CHANGES for us to merge.
+# (Same list as `required` minus optional ones, by default.)
+block_on_changes_requested: true
+
+# If a bot has not posted within this many minutes of PR open, treat as
+# "not installed" and skip waiting. 0 = wait forever (rely on bypass label).
+wait_minutes: 0

--- a/.github/review-bots.yml
+++ b/.github/review-bots.yml
@@ -13,7 +13,7 @@
 required:
   - login: copilot-pull-request-reviewer
     name: GitHub Copilot review
-    optional: false
+    optional: true
   - login: coderabbitai
     name: CodeRabbit
     optional: true   # mark optional until installed; flip to false after install

--- a/.github/scripts/pr_reviewer.py
+++ b/.github/scripts/pr_reviewer.py
@@ -20,9 +20,14 @@ from __future__ import annotations
 import os
 import re
 import sys
+from pathlib import Path
 from typing import Any
 
 import requests
+import yaml
+
+REVIEW_BOTS_CONFIG = Path(".github/review-bots.yml")
+BYPASS_LABEL = "bot-review-bypass"
 
 TOKEN = os.environ["GITHUB_TOKEN"]
 REPO = os.environ["REPO"]
@@ -68,6 +73,41 @@ def find_linked_issue(pr: dict[str, Any]) -> int | None:
     text = (pr.get("body") or "") + "\n" + (pr.get("title") or "")
     m = re.search(r"(?:close[sd]?|fixe[sd]?|resolve[sd]?)\s+#(\d+)", text, re.I)
     return int(m.group(1)) if m else None
+
+
+def load_required_bots() -> list[dict[str, Any]]:
+    if not REVIEW_BOTS_CONFIG.exists():
+        return []
+    try:
+        cfg = yaml.safe_load(REVIEW_BOTS_CONFIG.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as e:
+        sys.stderr.write(f"Could not parse {REVIEW_BOTS_CONFIG}: {e}\n")
+        return []
+    return cfg.get("required", []) or []
+
+
+def collect_bot_activity(reviews: list[dict], comments: list[dict]) -> dict[str, dict]:
+    """Map login.lower() -> {state, has_comment} summarizing each bot's latest input."""
+    out: dict[str, dict] = {}
+    for r in reviews:
+        login = ((r.get("user") or {}).get("login") or "").lower()
+        if not login:
+            continue
+        prev = out.get(login, {})
+        out[login] = {
+            "state": r.get("state"),  # APPROVED | CHANGES_REQUESTED | COMMENTED | DISMISSED
+            "has_comment": True,
+            "submitted_at": r.get("submitted_at") or prev.get("submitted_at"),
+        }
+    for c in comments:
+        login = ((c.get("user") or {}).get("login") or "").lower()
+        if not login or login in out:
+            continue
+        body = (c.get("body") or "").strip()
+        if len(body) < 40:
+            continue
+        out[login] = {"state": "COMMENTED", "has_comment": True, "submitted_at": c.get("created_at")}
+    return out
 
 
 def looks_like_path_match(touched: str, allowed: str) -> bool:
@@ -200,6 +240,35 @@ def main() -> int:
             "(branch protection enforces linear history on merge)."
         )
 
+    pr_labels = {(lbl.get("name") or "").lower() for lbl in (pr.get("labels") or [])}
+    bypass = BYPASS_LABEL.lower() in pr_labels
+
+    bot_activity: dict[str, dict] = {}
+    missing_required: list[str] = []
+    bots_changes_requested: list[str] = []
+    bot_status_lines: list[str] = []
+
+    if not violations and not bypass:
+        reviews = gh("GET", f"/repos/{REPO}/pulls/{PR_NUM}/reviews?per_page=100")
+        issue_comments = gh("GET", f"/repos/{REPO}/issues/{PR_NUM}/comments?per_page=100")
+        bot_activity = collect_bot_activity(reviews, issue_comments)
+
+        for spec in load_required_bots():
+            login = (spec.get("login") or "").lower()
+            display = spec.get("name") or spec.get("login") or "unknown"
+            if not login:
+                continue
+            act = bot_activity.get(login)
+            if not act:
+                if not spec.get("optional", False):
+                    missing_required.append(f"`{display}` (`@{spec['login']}`)")
+                bot_status_lines.append(f"  - {display}: _no review yet_" + (" (optional)" if spec.get("optional") else ""))
+                continue
+            state = (act.get("state") or "COMMENTED").upper()
+            bot_status_lines.append(f"  - {display}: **{state}**")
+            if state == "CHANGES_REQUESTED":
+                bots_changes_requested.append(f"`{display}`")
+
     parts = ["## Strict PR reviewer"]
     if info:
         parts.append("\n".join(f"- {i}" for i in info))
@@ -207,8 +276,24 @@ def main() -> int:
         parts.append("### Blocking issues\n\n" + "\n\n".join(f"- {v}" for v in violations))
     if warnings:
         parts.append("### Warnings\n\n" + "\n\n".join(f"- {w}" for w in warnings))
-    if not violations and not warnings:
-        parts.append("All checks passed. Approving and merging.")
+    if bot_status_lines:
+        parts.append("### AI review bot status\n\n" + "\n".join(bot_status_lines))
+    if bots_changes_requested:
+        parts.append(
+            "### AI bots requested changes\n\nMerge blocked until resolved: "
+            + ", ".join(bots_changes_requested)
+        )
+    if missing_required:
+        parts.append(
+            "### Waiting for AI bot reviews\n\nMerge held until the following bots post a review "
+            "(or apply label `" + BYPASS_LABEL + "` to skip the wait):\n\n"
+            + "\n".join(f"- {m}" for m in missing_required)
+        )
+    if not violations and not warnings and not missing_required and not bots_changes_requested:
+        if bypass:
+            parts.append(f"All checks passed. Bypass label `{BYPASS_LABEL}` present. Approving and merging.")
+        else:
+            parts.append("All checks passed and AI review bots are satisfied. Approving and merging.")
     body = "\n\n".join(parts)
 
     if violations:
@@ -216,9 +301,14 @@ def main() -> int:
         print(f"Requested changes on PR #{PR_NUM}.")
         return 0
 
-    if warnings or pending:
+    if warnings or pending or missing_required or bots_changes_requested:
         gh("POST", f"/repos/{REPO}/pulls/{PR_NUM}/reviews", json={"body": body, "event": "COMMENT"})
-        print(f"Commented on PR #{PR_NUM} (warnings or pending CI).")
+        reasons = []
+        if warnings: reasons.append("warnings")
+        if pending: reasons.append("pending CI")
+        if missing_required: reasons.append(f"waiting on bots: {', '.join(missing_required)}")
+        if bots_changes_requested: reasons.append(f"AI bots requested changes: {', '.join(bots_changes_requested)}")
+        print(f"Commented on PR #{PR_NUM} ({'; '.join(reasons)}).")
         return 0
 
     gh("POST", f"/repos/{REPO}/pulls/{PR_NUM}/reviews", json={"body": body, "event": "APPROVE"})

--- a/.github/scripts/pr_reviewer.py
+++ b/.github/scripts/pr_reviewer.py
@@ -301,10 +301,9 @@ def main() -> int:
         print(f"Requested changes on PR #{PR_NUM}.")
         return 0
 
-    if warnings or pending or missing_required or bots_changes_requested:
+    if pending or missing_required or bots_changes_requested:
         gh("POST", f"/repos/{REPO}/pulls/{PR_NUM}/reviews", json={"body": body, "event": "COMMENT"})
         reasons = []
-        if warnings: reasons.append("warnings")
         if pending: reasons.append("pending CI")
         if missing_required: reasons.append(f"waiting on bots: {', '.join(missing_required)}")
         if bots_changes_requested: reasons.append(f"AI bots requested changes: {', '.join(bots_changes_requested)}")

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -18,7 +18,11 @@ name: PR Reviewer Bot
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  issue_comment:
+    types: [created]
   check_run:
     types: [completed]
   workflow_dispatch:
@@ -33,7 +37,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || inputs.pr_number }}
+  group: pr-review-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.issue.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -41,6 +45,8 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.draft != true && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_review' && github.event.pull_request.draft != true && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
       (github.event_name == 'check_run' && github.event.check_run.pull_requests[0] != null)
     runs-on: ubuntu-latest
     steps:
@@ -51,6 +57,8 @@ jobs:
             echo "num=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "check_run" ]; then
             echo "num=${{ github.event.check_run.pull_requests[0].number }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "num=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
           else
             echo "num=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           fi
@@ -75,7 +83,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install reviewer deps
-        run: pip install --quiet requests
+        run: pip install --quiet requests pyyaml
 
       - name: Run strict reviewer
         env:

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,53 @@
+# https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/
+# Qodo Merge (formerly Codium PR-Agent) provides /review /improve /describe
+# /ask slash commands and can auto-run on PR open. Comment-only - does not
+# gate merges.
+
+[config]
+model = "gpt-4o-mini"  # vendor default; Qodo cloud uses its own free model on OSS
+fallback_models = ["gpt-4o"]
+verbosity_level = 1
+
+[github_app]
+# Run /review automatically on every PR open + sync.
+pr_commands = [
+    "/describe --pr_description.final_update_message=false",
+    "/review --pr_reviewer.num_code_suggestions=0",
+    "/improve --pr_code_suggestions.commitable_code_suggestions=false",
+]
+handle_pr_actions = ["opened", "reopened", "ready_for_review"]
+
+[pr_reviewer]
+require_score_review = false
+require_tests_review = true
+require_security_review = true
+require_focused_review = true
+num_code_suggestions = 4
+inline_code_comments = true
+ask_and_reflect = false
+extra_instructions = """
+This is a memory-constrained Python orchestrator (16GB host).
+- Flag any unbounded buffers, missing model.unload(), sync calls in async code.
+- Sanitize all tool inputs (paths, URLs, shell args).
+- Tests must mock external calls; never live network or real browsers in CI.
+- Conventional Commits required in PR title.
+"""
+
+[pr_description]
+publish_labels = false
+add_original_user_description = true
+keep_original_user_title = true
+extra_instructions = "Be terse. Bullet points only. No marketing fluff."
+
+[pr_code_suggestions]
+num_code_suggestions = 4
+commitable_code_suggestions = false
+extra_instructions = "Suggestions must explain the WHY, cite line numbers, and prefer stdlib over new deps."
+
+[ignore]
+glob = [
+    "**/*.lock",
+    "**/__snapshots__/**",
+    "docs/**/*.md",
+    ".venv/**",
+]

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,32 @@
+# https://docs.sourcery.ai/Configuration/Project-Settings/
+# Sourcery suggests Python refactorings on every PR. Comment-only - does
+# not gate merges.
+
+version: "1"
+
+rule_settings:
+  enable:
+    - default
+  disable:
+    - do-not-use-bare-except    # we already enforce via ruff E722
+  rule_types:
+    - refactoring
+    - suggestion
+    - comment
+
+python_version: "3.11"
+
+ignore:
+  - ".venv/**"
+  - "tests/**/conftest.py"
+  - "**/__snapshots__/**"
+  - "docs/**"
+
+github:
+  review: true
+  sourcery_branch: sourcery/{base_branch}
+  ignore_labels:
+    - sourcery-ignore
+
+metrics:
+  quality_threshold: 25.0

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This project is **agent-friendly**: every issue contains enough context, accepta
 3. Reference [`docs/PLAN.md`](docs/PLAN.md) for the bigger picture.
 4. Open a PR linking the issue (`Closes #N`).
 5. Follow [`CONTRIBUTING.md`](CONTRIBUTING.md).
+6. PRs are reviewed by a layered AI bot stack — see [`docs/REVIEW_BOTS.md`](docs/REVIEW_BOTS.md). Only our strict `code-reviewer-001` bot has merge authority; it waits for the AI bots to weigh in before approving.
 
 ## Tech stack
 

--- a/docs/REVIEW_BOTS.md
+++ b/docs/REVIEW_BOTS.md
@@ -1,0 +1,64 @@
+# AI & Static Code Review Bots
+
+This repository uses a **layered review model**: many bots post review comments;
+only **one** bot has merge authority.
+
+## The merge-gating bot
+
+| Bot | Role | Authority |
+|---|---|---|
+| `code-reviewer-001` (our GitHub App) | Strict reviewer — validates Conventional Commits, branch naming, linked-issue Acceptance Criteria, secret scanning, test coverage, CI status. | **Approves + squash-merges + deletes branch** when clean. Requests changes when violations exist. |
+
+Implementation lives in [`.github/scripts/pr_reviewer.py`](../.github/scripts/pr_reviewer.py)
+and [`.github/workflows/pr-reviewer.yml`](../.github/workflows/pr-reviewer.yml).
+
+## Comment-only AI review bots (free for public OSS)
+
+These bots post review comments but **never** gate the merge. They run in
+parallel with `code-reviewer-001`:
+
+| Bot | What it adds | Config | Install link |
+|---|---|---|---|
+| **GitHub Copilot review** | First-party AI review, summary + inline | none (workflow auto-requests) | Built into GitHub — free for public repos |
+| **CodeRabbit** | Line-by-line AI review, walkthrough, learnings | [`.coderabbit.yaml`](../.coderabbit.yaml) | <https://github.com/marketplace/coderabbitai> |
+| **Qodo Merge** (Codium PR-Agent) | `/review` `/improve` `/describe` `/ask` slash commands, auto-run on open | [`.pr_agent.toml`](../.pr_agent.toml) | <https://github.com/marketplace/qodo-merge-pro-for-open-source> |
+| **Gemini Code Assist** | Google AI review summary + inline issues | [`.gemini/config.yaml`](../.gemini/config.yaml) | <https://github.com/marketplace/gemini-code-assist> |
+| **Sourcery** | Python-specific refactoring suggestions | [`.sourcery.yaml`](../.sourcery.yaml) | <https://github.com/marketplace/sourcery-ai> |
+
+## Why this layering?
+
+1. **Signal vs. noise** — multiple AI reviewers catch different classes of
+   issue (CodeRabbit finds patterns, Sourcery finds Pythonic refactors,
+   Gemini/Copilot find logic bugs). Stacking is cheap on public repos.
+2. **Single source of merge truth** — only `code-reviewer-001` enforces our
+   project conventions (Conventional Commits, AC linkage, secret hygiene,
+   coverage). No third-party bot can merge.
+3. **Free and OSS-friendly** — every bot above is free for public
+   repositories. No paid tiers required.
+
+## Installation (one-time, by repo owner)
+
+The four third-party bots require a manual install via GitHub Marketplace
+(there is no API to install third-party Apps). Click each link above, choose
+**only this repository**, and complete the install. Configs are already
+checked in and will activate automatically on the first PR after install.
+
+## Opting out per PR
+
+Each bot supports a label or comment to skip review:
+
+| Bot | How to skip |
+|---|---|
+| CodeRabbit | comment `@coderabbitai pause` |
+| Qodo Merge | label `qodo-ignore` |
+| Gemini | comment `/gemini ignore` |
+| Sourcery | label `sourcery-ignore` |
+| Copilot | un-request the reviewer |
+
+`code-reviewer-001` **cannot** be skipped — it is the merge gate.
+
+## Static analysis (separate stack)
+
+Static analysis tools (CodeQL, Semgrep, Trivy, Gitleaks, Dependabot) are
+tracked separately in issue [#49](https://github.com/skgandikota/orchestrator/issues/49)
+and configured under [`.github/workflows/`](../.github/workflows/).


### PR DESCRIPTION
Closes #59

## Summary
Adds free OSS AI code-review bot configs (CodeRabbit, Qodo Merge, Gemini Code Assist, Sourcery) and changes our strict reviewer to **wait for those bots** before approving + merging.

## Acceptance Criteria met
- [x] `.coderabbit.yaml` — auto-review on, terse tone, path filters, per-path instructions for `tools/`, `models/`, and the reviewer script itself
- [x] `.pr_agent.toml` — Qodo Merge auto-runs `/describe /review /improve`, security + tests review on
- [x] `.gemini/config.yaml` — Gemini PR review enabled, MEDIUM severity threshold
- [x] `.sourcery.yaml` — Python 3.11+, refactor mode on, ignores tests/conftest
- [x] `docs/REVIEW_BOTS.md` documents layered model + install links + opt-out
- [x] `README.md` references `docs/REVIEW_BOTS.md`
- [x] No `orchestrator/` or `pyproject.toml` touched

## Reviewer-bot behaviour change
- New file `.github/review-bots.yml` lists required bot logins
- `pr_reviewer.py` now collects each required bot's latest review state and **blocks merge** until every required bot has posted (or `bot-review-bypass` label is applied)
- Workflow re-triggers on `pull_request_review`, `issue_comment`, and label changes so the reviewer re-evaluates whenever a bot weighs in
- All 4 third-party bots are marked `optional: true` for now (they need to be installed via Marketplace first); flip to `optional: false` after install

## Manual install required (one-time, by repo owner)
Direct Marketplace links are in `docs/REVIEW_BOTS.md`. After install, edit `.github/review-bots.yml` to flip each bot to `optional: false`.

## Files
- `.coderabbit.yaml`, `.pr_agent.toml`, `.gemini/config.yaml`, `.sourcery.yaml`, `.github/review-bots.yml`
- `.github/scripts/pr_reviewer.py` (patched), `.github/workflows/pr-reviewer.yml` (extended triggers)
- `docs/REVIEW_BOTS.md`, `README.md`
