### PR TITLE
feat(tools): browser tool for coder (Playwright subprocess)

### DIFF
--- a/orchestrator/tools/_browser_worker.py
+++ b/orchestrator/tools/_browser_worker.py
@@ -1,0 +1,183 @@
+"""Subprocess worker that owns the Playwright browser context.
+
+Run as ``python -m orchestrator.tools._browser_worker``. Communicates with
+the parent ``BrowserTool`` over stdio using line-delimited JSON-RPC.
+
+Each request is a JSON object on a single line::
+
+    {"id": 1, "method": "browse", "params": {"url": "https://example.com"}}
+
+Each response is::
+
+    {"id": 1, "result": {...}}
+    {"id": 1, "error": {"type": "...", "message": "..."}}
+
+Playwright is imported lazily on first use so that the parent process can
+spawn this module without paying the import cost (and so tests can stub
+the worker entirely without Playwright installed).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+DEFAULT_TEXT_CAP = 200 * 1024
+
+
+class _Worker:
+    def __init__(self, text_cap: int = DEFAULT_TEXT_CAP) -> None:
+        self.text_cap = text_cap
+        self._playwright = None
+        self._browser = None
+        self._context = None
+
+    # -- lifecycle ----------------------------------------------------
+    def _ensure_context(self):  # pragma: no cover - requires Playwright
+        if self._context is not None:
+            return self._context
+        from playwright.sync_api import sync_playwright
+
+        self._playwright = sync_playwright().start()
+        self._browser = self._playwright.chromium.launch(headless=True)
+        self._context = self._browser.new_context()
+        return self._context
+
+    def _open(self, url: str):  # pragma: no cover - requires Playwright
+        ctx = self._ensure_context()
+        page = ctx.new_page()
+        response = page.goto(url, wait_until="domcontentloaded")
+        return page, response
+
+    def _snapshot(self, page, response, url: str) -> dict[str, Any]:  # pragma: no cover
+        text = page.evaluate("() => document.body ? document.body.innerText : ''") or ""
+        if len(text) > self.text_cap:
+            text = text[: self.text_cap]
+        html = page.content()
+        if len(html) > self.text_cap:
+            html = html[: self.text_cap]
+        return {
+            "url": page.url or url,
+            "title": page.title() or "",
+            "text": text,
+            "html_truncated": html,
+            "status": response.status if response is not None else 0,
+        }
+
+    # -- handlers -----------------------------------------------------
+    def browse(self, url: str) -> dict[str, Any]:  # pragma: no cover
+        page, response = self._open(url)
+        try:
+            return self._snapshot(page, response, url)
+        finally:
+            page.close()
+
+    def screenshot(self, url: str) -> dict[str, Any]:  # pragma: no cover
+        import base64
+
+        page, _ = self._open(url)
+        try:
+            png = page.screenshot(full_page=True)
+        finally:
+            page.close()
+        return {"png_b64": base64.b64encode(png).decode("ascii")}
+
+    def extract(self, url: str, selector: str) -> dict[str, Any]:  # pragma: no cover
+        page, _ = self._open(url)
+        try:
+            handles = page.query_selector_all(selector)
+            values = [(h.inner_text() or "") for h in handles]
+        finally:
+            page.close()
+        return {"matches": values}
+
+    def click(self, url: str, selector: str) -> dict[str, Any]:  # pragma: no cover
+        page, response = self._open(url)
+        try:
+            page.click(selector)
+            page.wait_for_load_state("domcontentloaded")
+            return self._snapshot(page, response, url)
+        finally:
+            page.close()
+
+    def fill(self, url: str, selector: str, value: str) -> dict[str, Any]:  # pragma: no cover
+        page, response = self._open(url)
+        try:
+            page.fill(selector, value)
+            return self._snapshot(page, response, url)
+        finally:
+            page.close()
+
+    def shutdown(self) -> dict[str, Any]:  # pragma: no cover
+        try:
+            if self._context is not None:
+                self._context.close()
+            if self._browser is not None:
+                self._browser.close()
+            if self._playwright is not None:
+                self._playwright.stop()
+        finally:
+            self._context = None
+            self._browser = None
+            self._playwright = None
+        return {"ok": True}
+
+    # -- dispatch -----------------------------------------------------
+    def dispatch(self, method: str, params: dict[str, Any]) -> dict[str, Any]:  # pragma: no cover
+        if method == "browse":
+            return self.browse(params["url"])
+        if method == "screenshot":
+            return self.screenshot(params["url"])
+        if method == "extract":
+            return self.extract(params["url"], params["selector"])
+        if method == "click":
+            return self.click(params["url"], params["selector"])
+        if method == "fill":
+            return self.fill(params["url"], params["selector"], params["value"])
+        if method == "shutdown":
+            return self.shutdown()
+        raise ValueError(f"unknown method: {method}")
+
+
+def main() -> int:  # pragma: no cover - exercised only in real subprocess
+    worker = _Worker()
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as exc:
+            sys.stdout.write(
+                json.dumps({"id": None, "error": {"type": "ProtocolError", "message": str(exc)}})
+                + "\n"
+            )
+            sys.stdout.flush()
+            continue
+
+        rid = req.get("id")
+        method = req.get("method")
+        params = req.get("params") or {}
+        try:
+            result = worker.dispatch(method, params)
+            sys.stdout.write(json.dumps({"id": rid, "result": result}) + "\n")
+        except Exception as exc:
+            sys.stdout.write(
+                json.dumps(
+                    {
+                        "id": rid,
+                        "error": {"type": exc.__class__.__name__, "message": str(exc)},
+                    }
+                )
+                + "\n"
+            )
+        sys.stdout.flush()
+
+        if method == "shutdown":
+            return 0
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/orchestrator/tools/_url_guard.py
+++ b/orchestrator/tools/_url_guard.py
@@ -1,0 +1,74 @@
+"""Shared URL pre-flight guard for outbound coder tools.
+
+Blocks anything that is not plain ``http(s)`` or that resolves to a
+loopback / link-local / private / reserved address. Used by both
+``orchestrator.tools.web`` (when added) and ``orchestrator.tools.browser``
+so the policy lives in exactly one place.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+
+
+class UrlGuardError(ValueError):
+    """Raised when a URL fails the pre-flight guard."""
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def check_url(url: str, *, resolver=socket.getaddrinfo) -> str:
+    """Validate *url* and return its normalised form.
+
+    The optional ``resolver`` argument mirrors :func:`socket.getaddrinfo` so
+    tests can inject a fake without touching the network.
+    """
+    if not isinstance(url, str) or not url:
+        raise UrlGuardError("url must be a non-empty string")
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ALLOWED_SCHEMES:
+        raise UrlGuardError(f"scheme {parsed.scheme!r} is not allowed")
+    host = parsed.hostname
+    if not host:
+        raise UrlGuardError("url has no host")
+
+    # Literal IP fast-path.
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        ip = None
+
+    if ip is not None:
+        if _is_blocked_ip(ip):
+            raise UrlGuardError(f"host {host} resolves to a blocked address")
+        return url
+
+    try:
+        infos = resolver(host, None)
+    except OSError as exc:
+        raise UrlGuardError(f"could not resolve host {host!r}: {exc}") from exc
+
+    for info in infos:
+        sockaddr = info[4]
+        try:
+            resolved = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if _is_blocked_ip(resolved):
+            raise UrlGuardError(f"host {host} resolves to blocked address {resolved}")
+
+    return url

--- a/orchestrator/tools/browser.py
+++ b/orchestrator/tools/browser.py
@@ -1,0 +1,310 @@
+"""Coder-facing browser tool.
+
+Wraps a subprocess worker that owns a Playwright ``BrowserContext``.
+The worker is started lazily, reused across calls, and torn down on
+:meth:`BrowserTool.close`. Crashes or hangs are detected per-call and
+surface as :class:`BrowserToolError` while the process is respawned for
+the next call.
+
+The public surface is intentionally synchronous: any async behaviour
+lives inside the worker subprocess.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from ._url_guard import UrlGuardError, check_url
+
+DEFAULT_CALL_TIMEOUT = 30.0
+DEFAULT_IDLE_TIMEOUT = 300.0
+DEFAULT_TEXT_CAP = 200 * 1024
+
+
+class BrowserToolError(RuntimeError):
+    """Raised when the worker times out, crashes, or returns an error."""
+
+
+@dataclass(frozen=True)
+class PageSnapshot:
+    """Snapshot returned by navigation-style operations."""
+
+    url: str
+    title: str
+    text: str
+    html_truncated: str
+    status: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PageSnapshot:
+        return cls(
+            url=str(data.get("url", "")),
+            title=str(data.get("title", "")),
+            text=str(data.get("text", "")),
+            html_truncated=str(data.get("html_truncated", "")),
+            status=int(data.get("status", 0)),
+        )
+
+
+class _Transport(Protocol):
+    """Bidirectional line-delimited JSON channel to the worker."""
+
+    def send(self, line: str) -> None: ...
+    def recv(self, timeout: float) -> str | None: ...
+    def is_alive(self) -> bool: ...
+    def close(self) -> None: ...
+
+
+class _SubprocessTransport:
+    """Default transport: a real ``python -m`` subprocess."""
+
+    def __init__(self, argv: list[str] | None = None) -> None:
+        self._argv = argv or [sys.executable, "-m", "orchestrator.tools._browser_worker"]
+        self._proc: subprocess.Popen[str] | None = None
+        self._lines: list[str] = []
+        self._lock = threading.Lock()
+        self._reader: threading.Thread | None = None
+        self._start()
+
+    def _start(self) -> None:
+        self._proc = subprocess.Popen(
+            self._argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            bufsize=1,
+        )
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _read_loop(self) -> None:
+        assert self._proc is not None and self._proc.stdout is not None
+        for line in self._proc.stdout:
+            with self._lock:
+                self._lines.append(line)
+
+    def send(self, line: str) -> None:
+        if self._proc is None or self._proc.stdin is None:
+            raise BrowserToolError("worker stdin closed")
+        try:
+            self._proc.stdin.write(line if line.endswith("\n") else line + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError) as exc:
+            raise BrowserToolError(f"worker stdin write failed: {exc}") from exc
+
+    def recv(self, timeout: float) -> str | None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                if self._lines:
+                    return self._lines.pop(0)
+            if self._proc is not None and self._proc.poll() is not None:
+                with self._lock:
+                    if self._lines:
+                        return self._lines.pop(0)
+                return None
+            time.sleep(0.01)
+        return None
+
+    def is_alive(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    def close(self) -> None:
+        if self._proc is None:
+            return
+        try:
+            if self._proc.poll() is None:
+                self._proc.terminate()
+                try:
+                    self._proc.wait(timeout=2.0)
+                except subprocess.TimeoutExpired:
+                    self._proc.kill()
+                    self._proc.wait(timeout=2.0)
+        finally:
+            self._proc = None
+
+
+class BrowserTool:
+    """Synchronous browser tool callable from the coder dispatcher.
+
+    Parameters
+    ----------
+    call_timeout:
+        Per-call hard deadline (seconds). A timeout kills and respawns
+        the worker.
+    idle_timeout:
+        Worker is shut down if no call happens within this many seconds.
+    text_cap:
+        Soft upper bound (in characters) on ``text`` and ``html_truncated``
+        in returned snapshots. Enforced both in worker and parent.
+    transport_factory:
+        Test seam: a zero-arg callable returning a :class:`_Transport`.
+        Defaults to spawning the real subprocess worker.
+    """
+
+    def __init__(
+        self,
+        *,
+        call_timeout: float = DEFAULT_CALL_TIMEOUT,
+        idle_timeout: float = DEFAULT_IDLE_TIMEOUT,
+        text_cap: int = DEFAULT_TEXT_CAP,
+        transport_factory=None,
+        url_resolver=None,
+    ) -> None:
+        self.call_timeout = call_timeout
+        self.idle_timeout = idle_timeout
+        self.text_cap = text_cap
+        self._transport_factory = transport_factory or _SubprocessTransport
+        self._url_resolver = url_resolver
+        self._transport: _Transport | None = None
+        self._next_id = 0
+        self._last_used = 0.0
+        self._lock = threading.Lock()
+
+    # -- transport plumbing ------------------------------------------
+    def _ensure_transport(self) -> _Transport:
+        if self._transport is not None and self._transport.is_alive():
+            if (
+                self.idle_timeout > 0
+                and self._last_used
+                and time.monotonic() - self._last_used > self.idle_timeout
+            ):
+                self._teardown()
+            else:
+                return self._transport
+        self._teardown()
+        self._transport = self._transport_factory()
+        return self._transport
+
+    def _teardown(self) -> None:
+        if self._transport is not None:
+            with contextlib.suppress(Exception):
+                self._transport.close()
+            self._transport = None
+
+    def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            transport = self._ensure_transport()
+            self._next_id += 1
+            rid = self._next_id
+            payload = json.dumps({"id": rid, "method": method, "params": params})
+            try:
+                transport.send(payload)
+                raw = transport.recv(self.call_timeout)
+            except BrowserToolError:
+                self._teardown()
+                raise
+
+            if raw is None:
+                alive = transport.is_alive()
+                self._teardown()
+                if not alive:
+                    raise BrowserToolError(f"worker crashed during {method!r}")
+                raise BrowserToolError(f"worker timed out after {self.call_timeout}s on {method!r}")
+
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                self._teardown()
+                raise BrowserToolError(f"invalid worker response: {exc}") from exc
+
+            if "error" in msg and msg["error"] is not None:
+                err = msg["error"]
+                raise BrowserToolError(
+                    f"{err.get('type', 'WorkerError')}: {err.get('message', '')}"
+                )
+            self._last_used = time.monotonic()
+            return msg.get("result") or {}
+
+    # -- URL pre-flight ----------------------------------------------
+    def _guard(self, url: str) -> str:
+        try:
+            if self._url_resolver is not None:
+                return check_url(url, resolver=self._url_resolver)
+            return check_url(url)
+        except UrlGuardError as exc:
+            raise BrowserToolError(f"blocked url: {exc}") from exc
+
+    # -- snapshot post-processing ------------------------------------
+    def _cap(self, text: str) -> str:
+        if len(text) > self.text_cap:
+            return text[: self.text_cap]
+        return text
+
+    def _to_snapshot(self, raw: dict[str, Any]) -> PageSnapshot:
+        snap = PageSnapshot.from_dict(raw)
+        if len(snap.text) > self.text_cap or len(snap.html_truncated) > self.text_cap:
+            snap = PageSnapshot(
+                url=snap.url,
+                title=snap.title,
+                text=self._cap(snap.text),
+                html_truncated=self._cap(snap.html_truncated),
+                status=snap.status,
+            )
+        return snap
+
+    # -- public API --------------------------------------------------
+    def browse(self, url: str) -> PageSnapshot:
+        url = self._guard(url)
+        return self._to_snapshot(self._call("browse", {"url": url}))
+
+    def screenshot(self, url: str) -> bytes:
+        import base64
+
+        url = self._guard(url)
+        result = self._call("screenshot", {"url": url})
+        b64 = result.get("png_b64", "")
+        try:
+            return base64.b64decode(b64)
+        except (ValueError, TypeError) as exc:
+            raise BrowserToolError(f"invalid screenshot payload: {exc}") from exc
+
+    def extract(self, url: str, selector: str) -> list[str]:
+        url = self._guard(url)
+        result = self._call("extract", {"url": url, "selector": selector})
+        matches = result.get("matches", [])
+        if not isinstance(matches, list):
+            raise BrowserToolError("worker returned non-list matches")
+        return [str(m) for m in matches]
+
+    def click(self, url: str, selector: str) -> PageSnapshot:
+        url = self._guard(url)
+        return self._to_snapshot(self._call("click", {"url": url, "selector": selector}))
+
+    def fill(self, url: str, selector: str, value: str) -> PageSnapshot:
+        url = self._guard(url)
+        return self._to_snapshot(
+            self._call("fill", {"url": url, "selector": selector, "value": value})
+        )
+
+    def close(self) -> None:
+        if self._transport is None:
+            return
+        with self._lock:
+            try:
+                if self._transport.is_alive():
+                    self._next_id += 1
+                    payload = json.dumps(
+                        {"id": self._next_id, "method": "shutdown", "params": {}}
+                    )
+                    try:
+                        self._transport.send(payload)
+                        self._transport.recv(min(self.call_timeout, 5.0))
+                    except BrowserToolError:
+                        pass
+            finally:
+                self._teardown()
+
+    def __enter__(self) -> BrowserTool:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dev = [
     "ruff>=0.6",
     "mypy>=1.10",
 ]
+browser = [
+    "playwright>=1.40",
+]
 
 [project.urls]
 Homepage = "https://github.com/skgandikota/orchestrator"

--- a/tests/tools/test_browser.py
+++ b/tests/tools/test_browser.py
@@ -1,0 +1,263 @@
+"""Tests for orchestrator.tools.browser.
+
+The subprocess worker (and Playwright underneath) is replaced by an
+in-process fake transport so no real browser ever launches.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from orchestrator.tools._url_guard import UrlGuardError, check_url
+from orchestrator.tools.browser import (
+    BrowserTool,
+    BrowserToolError,
+    PageSnapshot,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake transport
+# ---------------------------------------------------------------------------
+class FakeTransport:
+    """In-process stand-in for the real subprocess transport."""
+
+    def __init__(self, *, responses=None, timeout_first=False, crash_after=None):
+        self.responses = list(responses or [])
+        self.sent: list[dict] = []
+        self._alive = True
+        self._timeout_first = timeout_first
+        self._crash_after = crash_after
+        self._calls = 0
+
+    def send(self, line: str) -> None:
+        self._calls += 1
+        self.sent.append(json.loads(line))
+        if self._crash_after is not None and self._calls > self._crash_after:
+            self._alive = False
+
+    def recv(self, timeout: float) -> str | None:
+        if self._timeout_first:
+            self._timeout_first = False
+            return None
+        if not self.responses:
+            return None
+        rid = self.sent[-1]["id"]
+        payload = self.responses.pop(0)
+        if "error" in payload:
+            return json.dumps({"id": rid, "error": payload["error"]})
+        return json.dumps({"id": rid, "result": payload.get("result", {})})
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def close(self) -> None:
+        self._alive = False
+
+
+def _factory(*transports):
+    """Build a transport_factory that yields the given transports in order."""
+    bucket = list(transports)
+
+    def make() -> FakeTransport:
+        return bucket.pop(0)
+
+    return make
+
+
+def _snap(**overrides):
+    base = {
+        "url": "https://example.com/",
+        "title": "Example",
+        "text": "hello",
+        "html_truncated": "<html>hi</html>",
+        "status": 200,
+    }
+    base.update(overrides)
+    return {"result": base}
+
+
+# ---------------------------------------------------------------------------
+# URL guard
+# ---------------------------------------------------------------------------
+def test_url_guard_accepts_public_literal():
+    assert check_url("https://1.1.1.1/path") == "https://1.1.1.1/path"
+
+
+def test_url_guard_rejects_private_literal():
+    with pytest.raises(UrlGuardError):
+        check_url("http://10.0.0.1/")
+
+
+def test_url_guard_rejects_loopback_literal():
+    with pytest.raises(UrlGuardError):
+        check_url("http://127.0.0.1/")
+
+
+def test_url_guard_rejects_bad_scheme():
+    with pytest.raises(UrlGuardError):
+        check_url("file:///etc/passwd")
+
+
+def test_url_guard_rejects_private_dns():
+    def fake_resolver(host, port):
+        return [(0, 0, 0, "", ("192.168.1.5", 0))]
+
+    with pytest.raises(UrlGuardError):
+        check_url("http://intranet.example/", resolver=fake_resolver)
+
+
+def test_url_guard_accepts_public_dns():
+    def fake_resolver(host, port):
+        return [(0, 0, 0, "", ("93.184.216.34", 0))]
+
+    assert check_url("https://example.com/", resolver=fake_resolver) == "https://example.com/"
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+def _public_resolver(host, port):
+    return [(0, 0, 0, "", ("93.184.216.34", 0))]
+
+
+def test_browse_returns_snapshot():
+    tx = FakeTransport(responses=[_snap()])
+    tool = BrowserTool(transport_factory=_factory(tx), url_resolver=_public_resolver)
+    snap = tool.browse("https://example.com/")
+    assert isinstance(snap, PageSnapshot)
+    assert snap.url == "https://example.com/"
+    assert snap.status == 200
+    assert tx.sent[0]["method"] == "browse"
+
+
+def test_screenshot_decodes_b64():
+    import base64
+
+    raw = b"\x89PNG\r\n\x1a\nfake"
+    tx = FakeTransport(responses=[{"result": {"png_b64": base64.b64encode(raw).decode()}}])
+    tool = BrowserTool(transport_factory=_factory(tx), url_resolver=_public_resolver)
+    assert tool.screenshot("https://example.com/") == raw
+
+
+def test_extract_returns_matches():
+    tx = FakeTransport(responses=[{"result": {"matches": ["a", "b"]}}])
+    tool = BrowserTool(transport_factory=_factory(tx), url_resolver=_public_resolver)
+    assert tool.extract("https://example.com/", "h1") == ["a", "b"]
+
+
+def test_extract_selector_miss_returns_empty():
+    tx = FakeTransport(responses=[{"result": {"matches": []}}])
+    tool = BrowserTool(transport_factory=_factory(tx), url_resolver=_public_resolver)
+    assert tool.extract("https://example.com/", ".missing") == []
+
+
+def test_click_and_fill_round_trip():
+    tx = FakeTransport(
+        responses=[
+            _snap(title="After click"),
+            _snap(title="After fill"),
+        ]
+    )
+    tool = BrowserTool(transport_factory=_factory(tx), url_resolver=_public_resolver)
+    s1 = tool.click("https://example.com/", "button#go")
+    s2 = tool.fill("https://example.com/", "input[name=q]", "hello")
+    assert s1.title == "After click"
+    assert s2.title == "After fill"
+    assert tx.sent[0]["method"] == "click"
+    assert tx.sent[1]["method"] == "fill"
+    assert tx.sent[1]["params"]["value"] == "hello"
+
+
+def test_text_is_capped():
+    big = "x" * 1000
+    tx = FakeTransport(responses=[_snap(text=big, html_truncated=big)])
+    tool = BrowserTool(
+        transport_factory=_factory(tx),
+        url_resolver=_public_resolver,
+        text_cap=100,
+    )
+    snap = tool.browse("https://example.com/")
+    assert len(snap.text) == 100
+    assert len(snap.html_truncated) == 100
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+def test_blocked_url_raises_before_call():
+    calls = {"made": 0}
+
+    def factory():
+        calls["made"] += 1
+        return FakeTransport()
+
+    tool = BrowserTool(transport_factory=factory)
+    with pytest.raises(BrowserToolError):
+        tool.browse("http://127.0.0.1/")
+    assert calls["made"] == 0
+
+
+def test_rpc_timeout_raises_and_respawns():
+    tx1 = FakeTransport(timeout_first=True)
+    tx2 = FakeTransport(responses=[_snap()])
+    tool = BrowserTool(
+        transport_factory=_factory(tx1, tx2),
+        url_resolver=_public_resolver,
+        call_timeout=0.05,
+    )
+    with pytest.raises(BrowserToolError, match="timed out"):
+        tool.browse("https://example.com/")
+    snap = tool.browse("https://example.com/")
+    assert snap.title == "Example"
+
+
+def test_worker_crash_auto_restarts():
+    tx_crashed = FakeTransport(responses=[_snap()], crash_after=0)
+    tx_fresh = FakeTransport(responses=[_snap(title="recovered")])
+    tool = BrowserTool(
+        transport_factory=_factory(tx_crashed, tx_fresh),
+        url_resolver=_public_resolver,
+    )
+    tool.browse("https://example.com/")
+    snap = tool.browse("https://example.com/")
+    assert snap.title == "recovered"
+
+
+def test_worker_crash_with_no_response_raises():
+    tx = FakeTransport(responses=[], crash_after=0)
+    tx2 = FakeTransport()
+    tool = BrowserTool(
+        transport_factory=_factory(tx, tx2),
+        url_resolver=_public_resolver,
+        call_timeout=0.05,
+    )
+    with pytest.raises(BrowserToolError, match="crashed"):
+        tool.browse("https://example.com/")
+
+
+def test_worker_returns_error_payload():
+    tx = FakeTransport(
+        responses=[{"error": {"type": "TimeoutError", "message": "nav failed"}}]
+    )
+    tool = BrowserTool(transport_factory=_factory(tx), url_resolver=_public_resolver)
+    with pytest.raises(BrowserToolError, match="TimeoutError"):
+        tool.browse("https://example.com/")
+
+
+def test_close_is_idempotent():
+    tx = FakeTransport(responses=[_snap(), {"result": {"ok": True}}])
+    tool = BrowserTool(transport_factory=_factory(tx), url_resolver=_public_resolver)
+    tool.browse("https://example.com/")
+    tool.close()
+    tool.close()
+    assert not tx.is_alive()
+
+
+def test_context_manager_closes():
+    tx = FakeTransport(responses=[_snap(), {"result": {"ok": True}}])
+    with BrowserTool(transport_factory=_factory(tx), url_resolver=_public_resolver) as tool:
+        tool.browse("https://example.com/")
+    assert not tx.is_alive()


### PR DESCRIPTION
Implements the coder-facing browser tool (Playwright in a separate subprocess).

## What

- `orchestrator/tools/browser.py` — synchronous `BrowserTool` exposing `browse`, `screenshot`, `extract`, `click`, `fill`, plus `PageSnapshot` dataclass and `BrowserToolError`.
- `orchestrator/tools/_browser_worker.py` — `python -m` subprocess that owns the Playwright `BrowserContext` and speaks line-delimited JSON-RPC over stdio. Playwright is only imported on first use.
- `orchestrator/tools/_url_guard.py` — shared scheme + private-IP guard (will be reused by `web.fetch`).
- `pyproject.toml` — adds `browser` optional-dependency group with `playwright>=1.40` so base install stays light.
- `tests/tools/test_browser.py` — fully mocked transport; no real browser ever launches.

## Acceptance Criteria met

- [x] Public API: `browse`, `screenshot`, `extract`, `click`, `fill` with `PageSnapshot` shape `{url,title,text,html_truncated,status}`.
- [x] Body text capped at configurable size (default 200 KB), enforced in both worker and parent.
- [x] All Playwright interaction lives in a subprocess worker, communicated via line-delimited JSON-RPC over stdio.
- [x] Worker started lazily, reused across calls, torn down on `BrowserTool.close()`; idle timeout drops it.
- [x] Per-call timeout (default 30 s) surfaces as `BrowserToolError` and respawns the worker; worker crash detected via `is_alive()` and auto-restarted on next call.
- [x] URL pre-flight via shared `_url_guard.check_url` (scheme + private-IP guard).
- [x] Tests cover happy `browse`/`screenshot`/`extract`/`click`/`fill`, selector miss, RPC timeout, worker crash auto-restart, worker-side error payload, URL guard rejections, and idempotent close.
- [x] Type hints on the public surface; `ruff check` clean; `pytest -q` green (32 passed).

Closes #28
