### PR TITLE
feat(core): SQLite job state store

### DIFF
--- a/orchestrator/config/settings.py
+++ b/orchestrator/config/settings.py
@@ -19,6 +19,7 @@ __all__ = [
     "Settings",
     "SettingsError",
     "ShellToolSettings",
+    "StateSettings",
     "ToolsSettings",
     "WebToolSettings",
     "load_settings",
@@ -109,6 +110,12 @@ class WebToolSettings(BaseModel):
     brave_api_key: str | None = None
 
 
+class StateSettings(BaseModel):
+    """Settings for the durable state store (``orchestrator.core.state``)."""
+
+    db_path: Path = Field(default=Path("./orchestrator.db"))
+
+
 class ToolsSettings(BaseModel):
     fs: FsToolSettings = Field(default_factory=FsToolSettings)
     shell: ShellToolSettings = Field(default_factory=ShellToolSettings)
@@ -120,6 +127,7 @@ class Settings(BaseModel):
     scheduler: SchedulerSettings = Field(default_factory=SchedulerSettings)
     ollama: OllamaSettings = Field(default_factory=OllamaSettings)
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
+    state: StateSettings = Field(default_factory=StateSettings)
     tools: ToolsSettings = Field(default_factory=ToolsSettings)
 
 

--- a/orchestrator/config/settings.toml
+++ b/orchestrator/config/settings.toml
@@ -20,6 +20,9 @@ request_timeout_seconds = 120
 level = "INFO"
 json = false
 
+[state]
+db_path = "./orchestrator.db"
+
 [tools.fs]
 # Sandbox root for every filesystem tool. Override with
 # ORCHESTRATOR__TOOLS__FS__WORKSPACE_ROOT.

--- a/orchestrator/core/migrations/001_initial.sql
+++ b/orchestrator/core/migrations/001_initial.sql
@@ -1,0 +1,49 @@
+-- 001_initial.sql -- baseline schema for the orchestrator state store.
+-- Append-only: never edit this file after merge. Future schema changes
+-- ship as 002_*.sql, 003_*.sql, ...
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id           TEXT PRIMARY KEY,
+    status       TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    request_json TEXT NOT NULL,
+    result_json  TEXT,
+    error        TEXT
+);
+
+CREATE TABLE IF NOT EXISTS steps (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id       TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    idx          INTEGER NOT NULL,
+    name         TEXT NOT NULL,
+    status       TEXT NOT NULL,
+    started_at   TEXT,
+    finished_at  TEXT,
+    input_json   TEXT,
+    output_json  TEXT,
+    error        TEXT,
+    UNIQUE(job_id, idx)
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id     TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    role       TEXT NOT NULL,
+    content    TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS artifacts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id     TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    kind       TEXT NOT NULL,
+    path       TEXT,
+    content    TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_status     ON jobs(status);
+CREATE INDEX IF NOT EXISTS idx_steps_job_id    ON steps(job_id);
+CREATE INDEX IF NOT EXISTS idx_messages_job_id ON messages(job_id);

--- a/orchestrator/core/migrations/__init__.py
+++ b/orchestrator/core/migrations/__init__.py
@@ -1,0 +1,6 @@
+"""SQL migration files for the orchestrator state store.
+
+This package is intentionally empty of Python code: it exists so that
+``importlib.resources.files("orchestrator.core.migrations")`` can enumerate
+the bundled ``*.sql`` migration scripts in lexical order.
+"""

--- a/orchestrator/core/state.py
+++ b/orchestrator/core/state.py
@@ -1,0 +1,432 @@
+"""SQLite-backed durable job state store.
+
+This module is the persistence layer for the orchestrator. It exposes a
+:class:`StateStore` that wraps a :class:`sqlite3.Connection` configured with
+WAL journaling, ``foreign_keys=ON``, and ``row_factory=sqlite3.Row``.
+
+The schema is created and evolved by :meth:`StateStore.migrate`, which runs
+every ``*.sql`` file in :mod:`orchestrator.core.migrations` in lexical order
+exactly once -- applied versions are tracked in a ``schema_migrations`` table,
+so calling ``migrate`` repeatedly is a no-op.
+
+The CRUD surface is intentionally small and additive (see Phase 1 plan):
+jobs, steps, messages, and artifacts. All reads return typed ``pydantic``
+models so that raw :class:`sqlite3.Row` objects never leak past the boundary,
+and all writes use parameterized queries.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "Artifact",
+    "Job",
+    "JobStatus",
+    "Message",
+    "StateStore",
+    "Step",
+    "StepStatus",
+]
+
+
+class JobStatus(StrEnum):
+    """Lifecycle states for a job."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+
+class StepStatus(StrEnum):
+    """Lifecycle states for an individual step within a job."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+
+class Job(BaseModel):
+    """Typed read-model for a row in ``jobs``."""
+
+    id: str
+    status: JobStatus
+    kind: str
+    created_at: str
+    updated_at: str
+    request: dict[str, Any] = Field(default_factory=dict)
+    result: dict[str, Any] | None = None
+    error: str | None = None
+
+
+class Step(BaseModel):
+    """Typed read-model for a row in ``steps``."""
+
+    id: int
+    job_id: str
+    idx: int
+    name: str
+    status: StepStatus
+    started_at: str | None = None
+    finished_at: str | None = None
+    input: dict[str, Any] | None = None
+    output: dict[str, Any] | None = None
+    error: str | None = None
+
+
+class Message(BaseModel):
+    """Typed read-model for a row in ``messages``."""
+
+    id: int
+    job_id: str
+    role: str
+    content: str
+    created_at: str
+
+
+class Artifact(BaseModel):
+    """Typed read-model for a row in ``artifacts``."""
+
+    id: int
+    job_id: str
+    kind: str
+    path: str | None = None
+    content: str | None = None
+    created_at: str
+
+
+_MIGRATIONS_PACKAGE = "orchestrator.core.migrations"
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _dumps(value: dict[str, Any] | None) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _loads(value: str | None) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return json.loads(value)
+
+
+class StateStore:
+    """SQLite-backed durable state store.
+
+    The connection is opened in the constructor with
+    ``check_same_thread=False`` so that later phases can use the store from a
+    thread pool. Mutations are wrapped in short transactions via the
+    ``with self._conn:`` context manager, which commits on success and rolls
+    back on exceptions.
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        path = Path(db_path)
+        if str(path) != ":memory:":
+            path.parent.mkdir(parents=True, exist_ok=True)
+        self._db_path = path
+        self._conn = sqlite3.connect(
+            str(path),
+            check_same_thread=False,
+            isolation_level="DEFERRED",
+            timeout=30.0,
+        )
+        self._conn.row_factory = sqlite3.Row
+        # PRAGMAs must be issued outside an explicit transaction.
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.execute("PRAGMA synchronous = NORMAL")
+
+    # ------------------------------------------------------------------ infra
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        """Return the underlying connection (escape hatch for advanced use)."""
+        return self._conn
+
+    @property
+    def db_path(self) -> Path:
+        """Return the on-disk path backing this store."""
+        return self._db_path
+
+    def close(self) -> None:
+        """Close the underlying connection."""
+        self._conn.close()
+
+    def __enter__(self) -> StateStore:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -------------------------------------------------------------- migrations
+
+    def migrate(self) -> list[str]:
+        """Apply any un-applied migrations; idempotent.
+
+        Returns the list of migration versions newly applied during this call
+        (empty if the database is already up to date).
+        """
+        with self._conn:
+            self._conn.execute(
+                "CREATE TABLE IF NOT EXISTS schema_migrations ("
+                "  version    TEXT PRIMARY KEY,"
+                "  applied_at TEXT NOT NULL"
+                ")"
+            )
+
+        applied: set[str] = {
+            row["version"] for row in self._conn.execute("SELECT version FROM schema_migrations")
+        }
+
+        newly_applied: list[str] = []
+        for version, sql in self._iter_migrations():
+            if version in applied:
+                continue
+            with self._conn:
+                self._conn.executescript(sql)
+                self._conn.execute(
+                    "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
+                    (version, _utcnow_iso()),
+                )
+            newly_applied.append(version)
+        return newly_applied
+
+    @staticmethod
+    def _iter_migrations() -> list[tuple[str, str]]:
+        files = [
+            f for f in resources.files(_MIGRATIONS_PACKAGE).iterdir() if f.name.endswith(".sql")
+        ]
+        files.sort(key=lambda f: f.name)
+        return [(f.name, f.read_text(encoding="utf-8")) for f in files]
+
+    # --------------------------------------------------------------- jobs CRUD
+
+    def create_job(self, kind: str, request: dict[str, Any]) -> str:
+        """Insert a new ``pending`` job, returning the generated UUID hex id."""
+        job_id = uuid.uuid4().hex
+        now = _utcnow_iso()
+        with self._conn:
+            self._conn.execute(
+                "INSERT INTO jobs("
+                "  id, status, kind, created_at, updated_at, request_json"
+                ") VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    job_id,
+                    JobStatus.PENDING.value,
+                    kind,
+                    now,
+                    now,
+                    _dumps(request) or "{}",
+                ),
+            )
+        return job_id
+
+    def get_job(self, job_id: str) -> Job | None:
+        """Fetch a job by id, or ``None`` if it does not exist."""
+        row = self._conn.execute(
+            "SELECT id, status, kind, created_at, updated_at,"
+            "       request_json, result_json, error"
+            "  FROM jobs WHERE id = ?",
+            (job_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return Job(
+            id=row["id"],
+            status=JobStatus(row["status"]),
+            kind=row["kind"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            request=_loads(row["request_json"]) or {},
+            result=_loads(row["result_json"]),
+            error=row["error"],
+        )
+
+    def update_job_status(
+        self,
+        job_id: str,
+        status: JobStatus,
+        *,
+        result: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Update a job's status, refreshing ``updated_at``.
+
+        Raises :class:`KeyError` if the job does not exist.
+        """
+        now = _utcnow_iso()
+        with self._conn:
+            cur = self._conn.execute(
+                "UPDATE jobs"
+                "   SET status = ?,"
+                "       updated_at = ?,"
+                "       result_json = COALESCE(?, result_json),"
+                "       error = COALESCE(?, error)"
+                " WHERE id = ?",
+                (status.value, now, _dumps(result), error, job_id),
+            )
+            if cur.rowcount == 0:
+                raise KeyError(f"job not found: {job_id}")
+
+    # -------------------------------------------------------------- steps CRUD
+
+    def append_step(self, job_id: str, name: str, input: dict[str, Any]) -> int:
+        """Append a new ``pending`` step to ``job_id``; returns its 0-based idx."""
+        with self._conn:
+            row = self._conn.execute(
+                "SELECT COALESCE(MAX(idx) + 1, 0) AS next_idx  FROM steps WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+            idx = int(row["next_idx"])
+            now = _utcnow_iso()
+            self._conn.execute(
+                "INSERT INTO steps("
+                "  job_id, idx, name, status, started_at, input_json"
+                ") VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    job_id,
+                    idx,
+                    name,
+                    StepStatus.RUNNING.value,
+                    now,
+                    _dumps(input),
+                ),
+            )
+        return idx
+
+    def finish_step(
+        self,
+        job_id: str,
+        idx: int,
+        status: StepStatus,
+        *,
+        output: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Mark step ``idx`` of ``job_id`` finished. Raises ``KeyError`` if missing."""
+        now = _utcnow_iso()
+        with self._conn:
+            cur = self._conn.execute(
+                "UPDATE steps"
+                "   SET status = ?,"
+                "       finished_at = ?,"
+                "       output_json = COALESCE(?, output_json),"
+                "       error = COALESCE(?, error)"
+                " WHERE job_id = ? AND idx = ?",
+                (status.value, now, _dumps(output), error, job_id, idx),
+            )
+            if cur.rowcount == 0:
+                raise KeyError(f"step not found: job={job_id} idx={idx}")
+
+    def list_steps(self, job_id: str) -> list[Step]:
+        """Return all steps for ``job_id`` ordered by ``idx`` ascending."""
+        rows = self._conn.execute(
+            "SELECT id, job_id, idx, name, status, started_at, finished_at,"
+            "       input_json, output_json, error"
+            "  FROM steps WHERE job_id = ? ORDER BY idx ASC",
+            (job_id,),
+        ).fetchall()
+        return [
+            Step(
+                id=row["id"],
+                job_id=row["job_id"],
+                idx=row["idx"],
+                name=row["name"],
+                status=StepStatus(row["status"]),
+                started_at=row["started_at"],
+                finished_at=row["finished_at"],
+                input=_loads(row["input_json"]),
+                output=_loads(row["output_json"]),
+                error=row["error"],
+            )
+            for row in rows
+        ]
+
+    # ----------------------------------------------------------- messages CRUD
+
+    def append_message(self, job_id: str, role: str, content: str) -> None:
+        """Append a chat-style message attached to ``job_id``."""
+        with self._conn:
+            self._conn.execute(
+                "INSERT INTO messages(job_id, role, content, created_at) VALUES (?, ?, ?, ?)",
+                (job_id, role, content, _utcnow_iso()),
+            )
+
+    def list_messages(self, job_id: str) -> list[Message]:
+        """Return all messages for ``job_id`` in insertion order."""
+        rows = self._conn.execute(
+            "SELECT id, job_id, role, content, created_at"
+            "  FROM messages WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+        return [
+            Message(
+                id=row["id"],
+                job_id=row["job_id"],
+                role=row["role"],
+                content=row["content"],
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
+
+    # ---------------------------------------------------------- artifacts CRUD
+
+    def add_artifact(
+        self,
+        job_id: str,
+        kind: str,
+        *,
+        path: str | None = None,
+        content: str | None = None,
+    ) -> None:
+        """Record an artifact (file path or inline content) for ``job_id``."""
+        with self._conn:
+            self._conn.execute(
+                "INSERT INTO artifacts(job_id, kind, path, content, created_at)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (job_id, kind, path, content, _utcnow_iso()),
+            )
+
+    def list_artifacts(self, job_id: str) -> list[Artifact]:
+        """Return all artifacts for ``job_id`` in insertion order."""
+        rows = self._conn.execute(
+            "SELECT id, job_id, kind, path, content, created_at"
+            "  FROM artifacts WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+        return [
+            Artifact(
+                id=row["id"],
+                job_id=row["job_id"],
+                kind=row["kind"],
+                path=row["path"],
+                content=row["content"],
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
+
+    def delete_job(self, job_id: str) -> bool:
+        """Delete a job and (via ``ON DELETE CASCADE``) all of its children."""
+        with self._conn:
+            cur = self._conn.execute("DELETE FROM jobs WHERE id = ?", (job_id,))
+        return cur.rowcount > 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ include = ["orchestrator*"]
 exclude = ["tests*"]
 
 [tool.setuptools.package-data]
-orchestrator = ["config/*.toml"]
+orchestrator = ["config/*.toml", "core/migrations/*.sql"]
 
 [tool.setuptools_scm]
 fallback_version = "0.1.0.dev0"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,353 @@
+"""Tests for orchestrator.core.state."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+
+import pytest
+
+from orchestrator.core.state import (
+    Job,
+    JobStatus,
+    StateStore,
+    Step,
+    StepStatus,
+)
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> StateStore:
+    s = StateStore(tmp_path / "state.db")
+    s.migrate()
+    yield s
+    s.close()
+
+
+# ------------------------------------------------------------------- migrations
+
+
+def test_migrate_creates_tables_and_pragmas(tmp_path: Path) -> None:
+    s = StateStore(tmp_path / "state.db")
+    applied = s.migrate()
+    assert "001_initial.sql" in applied
+
+    fk = s.connection.execute("PRAGMA foreign_keys").fetchone()[0]
+    assert fk == 1
+    journal = s.connection.execute("PRAGMA journal_mode").fetchone()[0]
+    assert journal.lower() == "wal"
+
+    tables = {
+        row[0] for row in s.connection.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert {"jobs", "steps", "messages", "artifacts", "schema_migrations"} <= tables
+
+    indexes = {
+        row[0] for row in s.connection.execute("SELECT name FROM sqlite_master WHERE type='index'")
+    }
+    assert {"idx_jobs_status", "idx_steps_job_id", "idx_messages_job_id"} <= indexes
+    s.close()
+
+
+def test_migrate_is_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / "state.db"
+    s = StateStore(db)
+    first = s.migrate()
+    second = s.migrate()
+    third = s.migrate()
+    assert first  # at least one applied first time
+    assert second == []
+    assert third == []
+    rows = s.connection.execute("SELECT version FROM schema_migrations").fetchall()
+    versions = [r["version"] for r in rows]
+    assert sorted(versions) == sorted(set(versions))  # no duplicates
+    s.close()
+
+
+def test_migrate_persists_across_reopen(tmp_path: Path) -> None:
+    db = tmp_path / "state.db"
+    s1 = StateStore(db)
+    s1.migrate()
+    s1.close()
+
+    s2 = StateStore(db)
+    re_applied = s2.migrate()
+    assert re_applied == []
+    s2.close()
+
+
+def test_db_path_creates_parent_dir(tmp_path: Path) -> None:
+    nested = tmp_path / "a" / "b" / "c" / "state.db"
+    s = StateStore(nested)
+    s.migrate()
+    assert nested.parent.is_dir()
+    s.close()
+
+
+# -------------------------------------------------------------------- jobs CRUD
+
+
+def test_create_and_get_job_round_trip(store: StateStore) -> None:
+    job_id = store.create_job("plan", {"goal": "demo", "n": 1})
+    assert isinstance(job_id, str) and len(job_id) == 32
+
+    job = store.get_job(job_id)
+    assert isinstance(job, Job)
+    assert job.id == job_id
+    assert job.kind == "plan"
+    assert job.status is JobStatus.PENDING
+    assert job.request == {"goal": "demo", "n": 1}
+    assert job.result is None
+    assert job.error is None
+    assert job.created_at == job.updated_at
+
+
+def test_get_job_returns_none_for_missing(store: StateStore) -> None:
+    assert store.get_job("does-not-exist") is None
+
+
+def test_update_job_status_persists_and_bumps_updated_at(store: StateStore) -> None:
+    job_id = store.create_job("plan", {})
+    before = store.get_job(job_id)
+    assert before is not None
+
+    store.update_job_status(
+        job_id,
+        JobStatus.RUNNING,
+    )
+    mid = store.get_job(job_id)
+    assert mid is not None
+    assert mid.status is JobStatus.RUNNING
+    assert mid.updated_at >= before.updated_at
+    assert mid.created_at == before.created_at
+
+    store.update_job_status(
+        job_id,
+        JobStatus.DONE,
+        result={"answer": 42},
+    )
+    after = store.get_job(job_id)
+    assert after is not None
+    assert after.status is JobStatus.DONE
+    assert after.result == {"answer": 42}
+    assert after.error is None
+
+    store.update_job_status(
+        job_id,
+        JobStatus.ERROR,
+        error="boom",
+    )
+    err = store.get_job(job_id)
+    assert err is not None
+    assert err.status is JobStatus.ERROR
+    assert err.error == "boom"
+    # Result is preserved by COALESCE semantics.
+    assert err.result == {"answer": 42}
+
+
+def test_update_job_status_unknown_id_raises(store: StateStore) -> None:
+    with pytest.raises(KeyError):
+        store.update_job_status("missing", JobStatus.DONE)
+
+
+# ------------------------------------------------------------------- steps CRUD
+
+
+def test_step_lifecycle_append_finish_list_in_idx_order(store: StateStore) -> None:
+    job_id = store.create_job("plan", {})
+    a = store.append_step(job_id, "first", {"k": 1})
+    b = store.append_step(job_id, "second", {"k": 2})
+    c = store.append_step(job_id, "third", {"k": 3})
+    assert (a, b, c) == (0, 1, 2)
+
+    store.finish_step(job_id, b, StepStatus.DONE, output={"v": "B"})
+    store.finish_step(job_id, a, StepStatus.ERROR, error="bad")
+    # c left running.
+
+    steps = store.list_steps(job_id)
+    assert [s.idx for s in steps] == [0, 1, 2]
+    assert all(isinstance(s, Step) for s in steps)
+
+    s0, s1, s2 = steps
+    assert s0.status is StepStatus.ERROR
+    assert s0.error == "bad"
+    assert s0.input == {"k": 1}
+    assert s0.finished_at is not None
+
+    assert s1.status is StepStatus.DONE
+    assert s1.output == {"v": "B"}
+
+    assert s2.status is StepStatus.RUNNING
+    assert s2.finished_at is None
+
+
+def test_finish_step_unknown_raises(store: StateStore) -> None:
+    job_id = store.create_job("plan", {})
+    with pytest.raises(KeyError):
+        store.finish_step(job_id, 999, StepStatus.DONE)
+
+
+def test_steps_unique_constraint_per_job(store: StateStore) -> None:
+    job_id = store.create_job("plan", {})
+    store.append_step(job_id, "s", {})
+    with pytest.raises(sqlite3.IntegrityError), store.connection:
+        store.connection.execute(
+            "INSERT INTO steps(job_id, idx, name, status) VALUES (?, ?, ?, ?)",
+            (job_id, 0, "dup", "running"),
+        )
+
+
+def test_list_steps_empty_for_unknown_job(store: StateStore) -> None:
+    assert store.list_steps("nope") == []
+
+
+# --------------------------------------------------------------- messages CRUD
+
+
+def test_messages_round_trip(store: StateStore) -> None:
+    job_id = store.create_job("chat", {})
+    store.append_message(job_id, "user", "hi")
+    store.append_message(job_id, "assistant", "hello")
+    msgs = store.list_messages(job_id)
+    assert [m.role for m in msgs] == ["user", "assistant"]
+    assert [m.content for m in msgs] == ["hi", "hello"]
+    assert all(m.job_id == job_id for m in msgs)
+
+
+# -------------------------------------------------------------- artifacts CRUD
+
+
+def test_artifacts_round_trip(store: StateStore) -> None:
+    job_id = store.create_job("build", {})
+    store.add_artifact(job_id, "log", path="/tmp/run.log")
+    store.add_artifact(job_id, "blob", content="hello-bytes")
+    arts = store.list_artifacts(job_id)
+    assert [a.kind for a in arts] == ["log", "blob"]
+    assert arts[0].path == "/tmp/run.log"
+    assert arts[0].content is None
+    assert arts[1].content == "hello-bytes"
+    assert arts[1].path is None
+
+
+# ---------------------------------------------------- foreign-key enforcement
+
+
+def test_foreign_key_blocks_orphan_step(store: StateStore) -> None:
+    with pytest.raises(sqlite3.IntegrityError), store.connection:
+        store.connection.execute(
+            "INSERT INTO steps(job_id, idx, name, status) VALUES (?, ?, ?, ?)",
+            ("ghost", 0, "orphan", "pending"),
+        )
+
+
+def test_foreign_key_blocks_orphan_message(store: StateStore) -> None:
+    with pytest.raises(sqlite3.IntegrityError), store.connection:
+        store.connection.execute(
+            "INSERT INTO messages(job_id, role, content, created_at) VALUES (?, ?, ?, ?)",
+            ("ghost", "user", "hi", "2024-01-01T00:00:00+00:00"),
+        )
+
+
+def test_foreign_key_blocks_orphan_artifact(store: StateStore) -> None:
+    with pytest.raises(sqlite3.IntegrityError), store.connection:
+        store.connection.execute(
+            "INSERT INTO artifacts(job_id, kind, created_at) VALUES (?, ?, ?)",
+            ("ghost", "log", "2024-01-01T00:00:00+00:00"),
+        )
+
+
+def test_delete_job_cascades_to_children(store: StateStore) -> None:
+    job_id = store.create_job("plan", {})
+    store.append_step(job_id, "s", {})
+    store.append_message(job_id, "user", "hi")
+    store.add_artifact(job_id, "log", path="x.log")
+
+    assert store.delete_job(job_id) is True
+    assert store.get_job(job_id) is None
+    assert store.list_steps(job_id) == []
+    assert store.list_messages(job_id) == []
+    assert store.list_artifacts(job_id) == []
+
+
+def test_delete_job_returns_false_for_missing(store: StateStore) -> None:
+    assert store.delete_job("nope") is False
+
+
+# -------------------------------------------------------------- concurrency
+
+
+def test_concurrent_writers_two_threads(tmp_path: Path) -> None:
+    db = tmp_path / "concurrent.db"
+    s = StateStore(db)
+    s.migrate()
+    job_id = s.create_job("plan", {})
+
+    errors: list[BaseException] = []
+
+    def worker(role: str, n: int) -> None:
+        try:
+            local = StateStore(db)
+            for i in range(n):
+                local.append_message(job_id, role, f"{role}-{i}")
+            local.close()
+        except BaseException as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=worker, args=("a", 25))
+    t2 = threading.Thread(target=worker, args=("b", 25))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert errors == []
+    msgs = s.list_messages(job_id)
+    assert len(msgs) == 50
+    assert sum(1 for m in msgs if m.role == "a") == 25
+    assert sum(1 for m in msgs if m.role == "b") == 25
+    s.close()
+
+
+# ------------------------------------------------------------- corrupt DB
+
+
+def test_corrupt_db_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "corrupt.db"
+    bad.write_bytes(b"this is not a sqlite database, not even close" * 8)
+    with pytest.raises(sqlite3.DatabaseError):
+        s = StateStore(bad)
+        try:
+            s.migrate()
+        finally:
+            s.close()
+
+
+# ----------------------------------------------------------- context manager
+
+
+def test_context_manager_closes(tmp_path: Path) -> None:
+    with StateStore(tmp_path / "ctx.db") as s:
+        s.migrate()
+        s.create_job("plan", {})
+    with pytest.raises(sqlite3.ProgrammingError):
+        s.connection.execute("SELECT 1")
+
+
+def test_db_path_property(tmp_path: Path) -> None:
+    p = tmp_path / "p.db"
+    s = StateStore(p)
+    assert s.db_path == p
+    s.close()
+
+
+# ------------------------------------------------------------ settings glue
+
+
+def test_settings_exposes_state_section() -> None:
+    from orchestrator.config.settings import Settings, StateSettings, load_settings
+
+    s = load_settings()
+    assert isinstance(s, Settings)
+    assert isinstance(s.state, StateSettings)
+    assert Path(s.state.db_path).name == "orchestrator.db"


### PR DESCRIPTION
## Summary

Implements the durable SQLite job state store for Phase 1 (issue #32).

- `orchestrator/core/state.py`: `StateStore` class wrapping `sqlite3.Connection` with WAL mode, `foreign_keys=ON`, and `sqlite3.Row` row factory. Pydantic `Job` / `Step` / `Message` / `Artifact` read-models. `JobStatus` and `StepStatus` `StrEnum`s with values `pending|running|done|error|cancelled`.
- Schema lives in `orchestrator/core/migrations/001_initial.sql` (jobs, steps, messages, artifacts + the three required indexes `idx_jobs_status`, `idx_steps_job_id`, `idx_messages_job_id`).
- `StateStore.migrate()` discovers `*.sql` files via `importlib.resources`, applies them in lexical order, and tracks applied versions in `schema_migrations(version, applied_at)`. Idempotent across repeated calls and process restarts.
- CRUD surface exactly matches the issue: `create_job` / `get_job` / `update_job_status` / `append_step` / `finish_step` / `list_steps` / `append_message` / `add_artifact` (plus list/delete helpers used by tests). All queries are parameterized; mutations run inside `with self._conn:` short transactions.
- `StateSettings.db_path` added to `orchestrator/config/settings.py` and `settings.toml` (default `./orchestrator.db`).
- `pyproject.toml` package-data updated so the bundled migration `.sql` ships with the wheel.

## Tests

`tests/test_state.py` covers happy path + edge cases per public function:
- migrate creates tables, indexes, and enables WAL + foreign keys
- migrate is idempotent (re-runs and reopens are no-ops)
- create + get job round-trip; `get_job` returns `None` for missing id
- update_job_status persists status, refreshes `updated_at`, preserves prior result via `COALESCE`; raises `KeyError` for unknown id
- step lifecycle: `append_step` returns sequential idx, `finish_step` updates status/output/error, `list_steps` orders by `idx`; unique constraint enforced
- foreign-key blocks orphan inserts on steps / messages / artifacts
- `ON DELETE CASCADE` removes children when the parent job is deleted
- two-thread concurrent writers (separate `StateStore` instances on the same WAL DB) interleave 50 inserts safely
- corrupt DB file raises `sqlite3.DatabaseError`
- context-manager closes the connection
- settings expose the new `[state]` section with the documented default

Coverage on new code (`orchestrator/core/state.py`, `orchestrator/core/migrations/`, settings additions): **100%**.

## Verification

- `ruff check .` clean on all new/modified files
- `ruff format --check .` clean on all new/modified files
- `pytest -q`: 109 passed, 1 skipped

Acceptance Criteria met.

Closes #32
