### PR TITLE
feat(tools): add OpenAI-style tool registry with dispatch envelope

### DIFF
--- a/orchestrator/tools/__init__.py
+++ b/orchestrator/tools/__init__.py
@@ -6,6 +6,7 @@ is wired up lazily by callers that have a config path — see
 ``orchestrator.cli`` and ``docs/PLAN.md`` for the wiring.
 """
 
+from . import _registrations  # noqa: F401  -- side-effect: populates default_registry
 from ._sandbox import WorkspaceEscapeError, resolve_in_workspace
 from .fs import delete_file, list_dir, read_file, write_file
 from .registry import Registry, Tool, ToolResult, default_registry

--- a/orchestrator/tools/_registrations.py
+++ b/orchestrator/tools/_registrations.py
@@ -1,0 +1,305 @@
+"""Default-registry registrations for the Phase 4 tools.
+
+This module wraps each Phase 4 tool's public functions in :class:`Tool`
+records and registers them on :data:`default_registry`. Importing
+:mod:`orchestrator.tools` runs this module, which is sufficient to populate
+the registry for the coder model. Tool source files are not modified —
+all hand-written OpenAI-compatible JSON Schemas live here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import fs as fs_tool
+from . import git as git_tool
+from . import shell as shell_tool
+from . import web as web_tool
+from .registry import Tool, default_registry
+
+__all__ = ["register_default_tools"]
+
+
+def _schema(properties: dict[str, dict[str, Any]], required: list[str]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+_FS_TOOLS: list[Tool] = [
+    Tool(
+        name="fs.read_file",
+        description="Read a UTF-8 text file from inside the workspace root.",
+        parameters_schema=_schema(
+            {"path": {"type": "string", "description": "Workspace-relative or absolute path."}},
+            ["path"],
+        ),
+        fn=fs_tool.read_file,
+        permissions={"fs_read": True},
+    ),
+    Tool(
+        name="fs.write_file",
+        description="Write UTF-8 content to a file inside the workspace root.",
+        parameters_schema=_schema(
+            {
+                "path": {"type": "string"},
+                "content": {"type": "string"},
+            },
+            ["path", "content"],
+        ),
+        fn=fs_tool.write_file,
+        permissions={"fs_write": True},
+    ),
+    Tool(
+        name="fs.list_dir",
+        description="List entries directly inside a workspace directory.",
+        parameters_schema=_schema({"path": {"type": "string"}}, ["path"]),
+        fn=fs_tool.list_dir,
+        permissions={"fs_read": True},
+    ),
+    Tool(
+        name="fs.delete_file",
+        description="Delete a single file inside the workspace root.",
+        parameters_schema=_schema({"path": {"type": "string"}}, ["path"]),
+        fn=fs_tool.delete_file,
+        permissions={"fs_write": True},
+    ),
+]
+
+
+_SHELL_TOOLS: list[Tool] = [
+    Tool(
+        name="shell.run_command",
+        description="Run an argv command inside the workspace, with allow/deny + timeout.",
+        parameters_schema=_schema(
+            {
+                "cmd": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "description": "Argv list; shell=False is enforced.",
+                },
+                "timeout": {"type": "number", "exclusiveMinimum": 0, "default": 30},
+                "cwd": {
+                    "type": ["string", "null"],
+                    "default": None,
+                    "description": "Workspace-relative cwd; defaults to workspace root.",
+                },
+            },
+            ["cmd"],
+        ),
+        fn=shell_tool.run_command,
+        permissions={"shell": True},
+    ),
+]
+
+
+_WEB_TOOLS: list[Tool] = [
+    Tool(
+        name="web.fetch",
+        description="Fetch a URL via HTTP(S) and return sanitised text + metadata.",
+        parameters_schema=_schema(
+            {
+                "url": {"type": "string", "format": "uri"},
+                "max_bytes": {"type": "integer", "exclusiveMinimum": 0, "default": 1000000},
+                "timeout": {"type": "number", "exclusiveMinimum": 0, "default": 15},
+            },
+            ["url"],
+        ),
+        fn=web_tool.fetch,
+        permissions={"network": True},
+    ),
+    Tool(
+        name="web.search",
+        description="Run a web search via DuckDuckGo (default) or Brave.",
+        parameters_schema=_schema(
+            {
+                "query": {"type": "string", "minLength": 1},
+                "provider": {
+                    "type": "string",
+                    "enum": ["duckduckgo", "brave"],
+                    "default": "duckduckgo",
+                },
+                "limit": {"type": "integer", "minimum": 1, "default": 10},
+            },
+            ["query"],
+        ),
+        fn=web_tool.search,
+        permissions={"network": True},
+    ),
+]
+
+
+_GIT_TOOLS: list[Tool] = [
+    Tool(
+        name="git.status",
+        description="Return parsed `git status --porcelain=v2 --branch` for the workspace.",
+        parameters_schema=_schema({}, []),
+        fn=git_tool.status,
+        permissions={"shell": True},
+    ),
+    Tool(
+        name="git.diff",
+        description="Return `git diff` (or `--cached` when staged=true) for the workspace.",
+        parameters_schema=_schema(
+            {
+                "staged": {"type": "boolean", "default": False},
+                "path": {"type": ["string", "null"], "default": None},
+            },
+            [],
+        ),
+        fn=git_tool.diff,
+        permissions={"shell": True},
+    ),
+    Tool(
+        name="git.commit",
+        description="Create a commit and return the new SHA.",
+        parameters_schema=_schema(
+            {
+                "message": {"type": "string", "minLength": 1},
+                "add_all": {"type": "boolean", "default": False},
+            },
+            ["message"],
+        ),
+        fn=git_tool.commit,
+        permissions={"shell": True},
+    ),
+    Tool(
+        name="git.branch",
+        description="Create a new git branch (no checkout).",
+        parameters_schema=_schema({"name": {"type": "string", "minLength": 1}}, ["name"]),
+        fn=git_tool.branch,
+        permissions={"shell": True},
+    ),
+    Tool(
+        name="git.checkout",
+        description="Switch HEAD to ref, optionally creating it. Refuses dirty trees.",
+        parameters_schema=_schema(
+            {
+                "ref": {"type": "string", "minLength": 1},
+                "create": {"type": "boolean", "default": False},
+            },
+            ["ref"],
+        ),
+        fn=git_tool.checkout,
+        permissions={"shell": True},
+    ),
+    Tool(
+        name="git.log",
+        description="Return the most recent N commits on HEAD.",
+        parameters_schema=_schema({"n": {"type": "integer", "minimum": 0, "default": 10}}, []),
+        fn=git_tool.log,
+        permissions={"shell": True},
+    ),
+    Tool(
+        name="git.current_branch",
+        description="Return the symbolic name of the current branch.",
+        parameters_schema=_schema({}, []),
+        fn=git_tool.current_branch,
+        permissions={"shell": True},
+    ),
+]
+
+
+# Browser tools wrap a lazily-instantiated singleton so registration at
+# import time does not spawn a Playwright worker. The wrapper closures
+# instantiate on first call.
+_browser_singleton: Any = None
+
+
+def _get_browser() -> Any:
+    global _browser_singleton
+    if _browser_singleton is None:
+        from .browser import BrowserTool
+
+        _browser_singleton = BrowserTool()
+    return _browser_singleton
+
+
+def _browser_browse(url: str) -> Any:
+    return _get_browser().browse(url)
+
+
+def _browser_extract(url: str, selector: str) -> list[str]:
+    return _get_browser().extract(url, selector)
+
+
+def _browser_click(url: str, selector: str) -> Any:
+    return _get_browser().click(url, selector)
+
+
+def _browser_fill(url: str, selector: str, value: str) -> Any:
+    return _get_browser().fill(url, selector, value)
+
+
+_BROWSER_TOOLS: list[Tool] = [
+    Tool(
+        name="browser.browse",
+        description="Navigate to URL and return a PageSnapshot (url/title/text/html/status).",
+        parameters_schema=_schema({"url": {"type": "string", "format": "uri"}}, ["url"]),
+        fn=_browser_browse,
+        permissions={"network": True, "browser": True},
+    ),
+    Tool(
+        name="browser.extract",
+        description="Navigate to URL and return matched text for a CSS selector.",
+        parameters_schema=_schema(
+            {
+                "url": {"type": "string", "format": "uri"},
+                "selector": {"type": "string", "minLength": 1},
+            },
+            ["url", "selector"],
+        ),
+        fn=_browser_extract,
+        permissions={"network": True, "browser": True},
+    ),
+    Tool(
+        name="browser.click",
+        description="Navigate to URL, click a CSS selector, return the post-click snapshot.",
+        parameters_schema=_schema(
+            {
+                "url": {"type": "string", "format": "uri"},
+                "selector": {"type": "string", "minLength": 1},
+            },
+            ["url", "selector"],
+        ),
+        fn=_browser_click,
+        permissions={"network": True, "browser": True},
+    ),
+    Tool(
+        name="browser.fill",
+        description="Navigate to URL, fill a CSS selector with value, return the snapshot.",
+        parameters_schema=_schema(
+            {
+                "url": {"type": "string", "format": "uri"},
+                "selector": {"type": "string", "minLength": 1},
+                "value": {"type": "string"},
+            },
+            ["url", "selector", "value"],
+        ),
+        fn=_browser_fill,
+        permissions={"network": True, "browser": True},
+    ),
+]
+
+
+_ALL_TOOLS: list[Tool] = [
+    *_FS_TOOLS,
+    *_SHELL_TOOLS,
+    *_WEB_TOOLS,
+    *_GIT_TOOLS,
+    *_BROWSER_TOOLS,
+]
+
+
+def register_default_tools() -> None:
+    """Register every Phase 4 tool on :data:`default_registry` (idempotent)."""
+    for tool in _ALL_TOOLS:
+        if default_registry.get(tool.name) is None:
+            default_registry.register(tool)
+
+
+register_default_tools()

--- a/orchestrator/tools/registry.py
+++ b/orchestrator/tools/registry.py
@@ -1,22 +1,34 @@
-"""Minimal in-process tool registry.
+"""Tool registry for the orchestrator's coder model.
 
-Provides the ``Tool`` / ``ToolResult`` data types and a thread-safe
-``Registry`` that maps tool names to async callables. The MCP client
-(:mod:`orchestrator.tools.mcp_client`) uses this registry to surface
-remote MCP tools alongside built-in tools.
+This module unifies two API surfaces that landed in parallel:
 
-This is a lightweight stand-in for the richer registry tracked in
-issue #30; the public surface (``register`` / ``unregister`` / ``get``
-/ ``names``) is kept small and stable so the larger registry can drop
-in without breaking callers.
+* The richer OpenAI-style registry from issue #30 (this PR): it validates
+  arguments against a JSON Schema before invoking the tool callable, times
+  every dispatch, and emits the ``tools=[...]`` payload expected by
+  ``openai.chat.completions.create``.
+* The minimal in-process registry that ``orchestrator.tools.mcp_client``
+  depends on (landed via PR #75 on ``main``): it adds a ``source`` field on
+  ``Tool`` (``builtin`` vs ``mcp``), thread-safe access, and helpers like
+  ``by_source`` / ``clear`` / ``__contains__`` / ``__len__`` plus a
+  ``register(..., replace=True)`` keyword for refreshing remote tools.
+
+Both surfaces are kept here as a union so the MCP client and the coder
+model can share a single :data:`default_registry`. ``ToolResult`` exposes
+``data`` and ``content`` as aliases for the same payload so callers using
+either name keep working.
 """
 
 from __future__ import annotations
 
+import inspect
 import threading
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from time import perf_counter
 from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = [
     "Registry",
@@ -26,62 +38,98 @@ __all__ = [
 ]
 
 
-@dataclass(slots=True)
-class ToolResult:
-    """Standard envelope returned by every tool dispatch."""
+class Tool(BaseModel):
+    """A single registered tool callable."""
 
-    ok: bool
-    content: Any = None
-    error: str | None = None
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
-
-@dataclass(slots=True)
-class Tool:
-    """A registered tool callable by the orchestrator."""
-
-    name: str
-    description: str
-    parameters_schema: dict[str, Any] = field(default_factory=dict)
-    fn: Callable[..., Awaitable[ToolResult]] | None = None
+    name: str = Field(min_length=1)
+    description: str = ""
+    parameters_schema: dict[str, Any] = Field(default_factory=dict)
+    fn: Callable[..., Any] | Callable[..., Awaitable[Any]] | None = None
+    permissions: dict[str, bool] = Field(default_factory=dict)
     source: str = "builtin"
 
 
+class ToolResult(BaseModel):
+    """Uniform envelope for every dispatch outcome.
+
+    ``data`` and ``content`` are aliases for the same payload: callers from
+    the coder dispatch path use ``data`` while the MCP client uses
+    ``content``. Both attributes are populated and stay in sync.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    ok: bool
+    data: Any | None = None
+    content: Any | None = None
+    error: str | None = None
+    duration_ms: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def _sync_data_content(self) -> ToolResult:
+        # Mirror data <-> content so either accessor returns the payload.
+        if self.data is None and self.content is not None:
+            object.__setattr__(self, "data", self.content)
+        elif self.content is None and self.data is not None:
+            object.__setattr__(self, "content", self.data)
+        return self
+
+
 class Registry:
-    """In-process map of tool name → :class:`Tool`."""
+    """Holds tools by unique name and dispatches calls into them.
+
+    Thread-safe. Supports both the duplicate-rejecting ``register(tool)``
+    style from the coder dispatch path and ``register(tool, replace=True)``
+    from the MCP client (which refreshes remote tools on reconnect).
+    """
 
     def __init__(self) -> None:
         self._tools: dict[str, Tool] = {}
         self._lock = threading.RLock()
 
     def register(self, tool: Tool, *, replace: bool = False) -> None:
-        """Add ``tool`` to the registry.
+        """Register *tool*. Rejects duplicate names unless ``replace=True``.
 
-        Raises:
-            ValueError: When a tool with the same name already exists and
-                ``replace`` is ``False``.
+        Also validates ``parameters_schema`` against JSON Schema 2020-12
+        (skipped when the schema is empty, e.g. for tools registered by
+        ``orchestrator.tools.mcp_client`` before the remote schema arrives).
         """
         with self._lock:
             if tool.name in self._tools and not replace:
-                raise ValueError(f"tool {tool.name!r} already registered")
+                raise ValueError(f"tool already registered: {tool.name!r}")
+            if tool.parameters_schema:
+                try:
+                    Draft202012Validator.check_schema(tool.parameters_schema)
+                except SchemaError as exc:
+                    raise ValueError(
+                        f"invalid parameters_schema for tool {tool.name!r}: {exc.message}"
+                    ) from exc
             self._tools[tool.name] = tool
 
     def unregister(self, name: str) -> None:
+        """Remove *name* if present (no-op otherwise)."""
         with self._lock:
             self._tools.pop(name, None)
 
-    def get(self, name: str) -> Tool:
+    def get(self, name: str) -> Tool | None:
+        """Return the tool registered under *name* or ``None``."""
         with self._lock:
-            return self._tools[name]
+            return self._tools.get(name)
 
     def names(self) -> list[str]:
+        """Return registered tool names in stable (sorted) order."""
         with self._lock:
             return sorted(self._tools)
 
     def by_source(self, source: str) -> list[Tool]:
+        """Return tools whose ``source`` matches *source*."""
         with self._lock:
             return [t for t in self._tools.values() if t.source == source]
 
     def clear(self) -> None:
+        """Remove every registered tool."""
         with self._lock:
             self._tools.clear()
 
@@ -92,6 +140,74 @@ class Registry:
     def __len__(self) -> int:
         with self._lock:
             return len(self._tools)
+
+    def dispatch(self, name: str, args: dict[str, Any]) -> ToolResult:
+        """Validate *args* and invoke the tool *name*.
+
+        Always returns a :class:`ToolResult`; exceptions raised by the tool
+        callable are captured into ``error`` with ``ok=False``. Async
+        callables (used by the MCP client) are not awaited here -- callers
+        that register async tools should use the async dispatcher provided
+        by :mod:`orchestrator.tools.mcp_client` instead.
+        """
+        start = perf_counter()
+        with self._lock:
+            tool = self._tools.get(name)
+
+        def _ms() -> int:
+            return int((perf_counter() - start) * 1000)
+
+        if tool is None:
+            return ToolResult(ok=False, error=f"unknown tool: {name!r}", duration_ms=_ms())
+
+        if tool.parameters_schema:
+            validator = Draft202012Validator(tool.parameters_schema)
+            try:
+                validator.validate(args)
+            except ValidationError as exc:
+                return ToolResult(
+                    ok=False,
+                    error=f"ValidationError: {exc.message}",
+                    duration_ms=_ms(),
+                )
+
+        if tool.fn is None:
+            return ToolResult(
+                ok=False, error=f"tool {name!r} has no callable bound", duration_ms=_ms()
+            )
+
+        try:
+            result = tool.fn(**args)
+        except Exception as exc:
+            return ToolResult(ok=False, error=f"{type(exc).__name__}: {exc}", duration_ms=_ms())
+
+        if inspect.isawaitable(result):
+            return ToolResult(
+                ok=False,
+                error=(
+                    f"tool {name!r} is async; use the async dispatcher "
+                    "(orchestrator.tools.mcp_client)"
+                ),
+                duration_ms=_ms(),
+            )
+
+        return ToolResult(ok=True, data=result, duration_ms=_ms())
+
+    def openai_tools_spec(self) -> list[dict[str, Any]]:
+        """Return ``tools=[...]`` payload for ``chat.completions.create``."""
+        with self._lock:
+            items = sorted(self._tools.items())
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters_schema,
+                },
+            }
+            for _, tool in items
+        ]
 
 
 default_registry = Registry()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "duckduckgo-search>=6.0",
     "mcp>=1.0,<2",
     "pyyaml>=6.0",
+    "jsonschema>=4.21",
 ]
 
 [project.scripts]

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,12 +1,359 @@
-"""Tests for the minimal in-process tool registry."""
+"""Tests for the tool registry."""
 
 from __future__ import annotations
 
 import pytest
 
+from orchestrator.tools import default_registry as _default_registry  # noqa: F401
 from orchestrator.tools.registry import Registry, Tool, ToolResult, default_registry
 
 
+def _add(a: int, b: int) -> int:
+    return a + b
+
+
+def _add_schema() -> dict:
+    return {
+        "type": "object",
+        "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+        "required": ["a", "b"],
+        "additionalProperties": False,
+    }
+
+
+def _make_tool(**overrides) -> Tool:
+    base = {
+        "name": "math.add",
+        "description": "Return a + b.",
+        "parameters_schema": _add_schema(),
+        "fn": _add,
+    }
+    base.update(overrides)
+    return Tool(**base)
+
+
+# -- Registration ----------------------------------------------------------
+
+
+def test_register_and_lookup() -> None:
+    reg = Registry()
+    tool = _make_tool()
+    reg.register(tool)
+    assert reg.get("math.add") is tool
+    assert reg.names() == ["math.add"]
+
+
+def test_register_rejects_duplicate_name() -> None:
+    reg = Registry()
+    reg.register(_make_tool())
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(_make_tool())
+
+
+def test_register_rejects_invalid_schema() -> None:
+    reg = Registry()
+    bad = _make_tool(parameters_schema={"type": "not-a-type"})
+    with pytest.raises(ValueError, match="invalid parameters_schema"):
+        reg.register(bad)
+
+
+def test_unregister_is_noop_for_unknown() -> None:
+    reg = Registry()
+    reg.unregister("nope")
+    assert reg.names() == []
+
+
+def test_get_missing_returns_none() -> None:
+    assert Registry().get("missing") is None
+
+
+def test_names_returns_stable_sorted_order() -> None:
+    reg = Registry()
+    reg.register(_make_tool(name="zeta"))
+    reg.register(_make_tool(name="alpha"))
+    reg.register(_make_tool(name="mu"))
+    assert reg.names() == ["alpha", "mu", "zeta"]
+
+
+def test_tool_is_frozen() -> None:
+    from pydantic import ValidationError
+
+    tool = _make_tool()
+    with pytest.raises(ValidationError):
+        tool.name = "other"  # type: ignore[misc]
+
+
+# -- Dispatch --------------------------------------------------------------
+
+
+def test_dispatch_happy_path() -> None:
+    reg = Registry()
+    reg.register(_make_tool())
+    result = reg.dispatch("math.add", {"a": 2, "b": 3})
+    assert isinstance(result, ToolResult)
+    assert result.ok is True
+    assert result.data == 5
+    assert result.error is None
+    assert result.duration_ms >= 0
+
+
+def test_dispatch_unknown_tool_returns_error_envelope() -> None:
+    reg = Registry()
+    result = reg.dispatch("nope", {})
+    assert result.ok is False
+    assert result.data is None
+    assert "unknown tool" in (result.error or "")
+    assert result.duration_ms >= 0
+
+
+def test_dispatch_invalid_args_does_not_call_fn() -> None:
+    calls: list[dict] = []
+
+    def fn(**kwargs: object) -> object:
+        calls.append(kwargs)
+        return "ran"
+
+    reg = Registry()
+    reg.register(_make_tool(fn=fn))
+    result = reg.dispatch("math.add", {"a": "not-an-int", "b": 3})
+    assert result.ok is False
+    assert result.error is not None and result.error.startswith("ValidationError")
+    assert calls == []
+
+
+def test_dispatch_missing_required_is_validation_error() -> None:
+    reg = Registry()
+    reg.register(_make_tool())
+    result = reg.dispatch("math.add", {"a": 1})
+    assert result.ok is False
+    assert result.error is not None and result.error.startswith("ValidationError")
+
+
+def test_dispatch_captures_fn_exception() -> None:
+    def boom(**_: object) -> None:
+        raise RuntimeError("kaboom")
+
+    reg = Registry()
+    reg.register(_make_tool(fn=boom))
+    result = reg.dispatch("math.add", {"a": 1, "b": 2})
+    assert result.ok is False
+    assert result.error == "RuntimeError: kaboom"
+    assert result.data is None
+    assert result.duration_ms >= 0
+
+
+def test_dispatch_timing_populated_even_on_failure() -> None:
+    reg = Registry()
+    result = reg.dispatch("missing", {})
+    assert result.duration_ms >= 0
+
+
+# -- OpenAI spec -----------------------------------------------------------
+
+
+def test_openai_tools_spec_shape() -> None:
+    reg = Registry()
+    reg.register(_make_tool())
+    spec = reg.openai_tools_spec()
+    assert isinstance(spec, list)
+    assert spec == [
+        {
+            "type": "function",
+            "function": {
+                "name": "math.add",
+                "description": "Return a + b.",
+                "parameters": _add_schema(),
+            },
+        }
+    ]
+
+
+def test_openai_tools_spec_sorted_by_name() -> None:
+    reg = Registry()
+    reg.register(_make_tool(name="zeta"))
+    reg.register(_make_tool(name="alpha"))
+    spec = reg.openai_tools_spec()
+    assert [entry["function"]["name"] for entry in spec] == ["alpha", "zeta"]
+
+
+# -- Default registry / phase-4 wiring ------------------------------------
+
+
+def test_default_registry_is_singleton_module_export() -> None:
+    from orchestrator.tools import registry as registry_mod
+
+    assert default_registry is registry_mod.default_registry
+
+
+def test_phase4_tools_registered_on_default_registry() -> None:
+    import orchestrator.tools  # noqa: F401  -- ensure registrations ran
+    from orchestrator.tools._registrations import register_default_tools
+
+    # Other test modules (notably tests/tools/test_mcp_client.py) call
+    # ``default_registry.clear()`` and rely on import-time side effects to
+    # have happened. Re-run registrations to keep this test order-agnostic.
+    register_default_tools()
+
+    names = set(default_registry.names())
+    expected = {
+        "fs.read_file",
+        "fs.write_file",
+        "fs.list_dir",
+        "fs.delete_file",
+        "shell.run_command",
+        "web.fetch",
+        "web.search",
+        "git.status",
+        "git.diff",
+        "git.commit",
+        "git.branch",
+        "git.checkout",
+        "git.log",
+        "git.current_branch",
+        "browser.browse",
+        "browser.extract",
+        "browser.click",
+        "browser.fill",
+    }
+    missing = expected - names
+    assert not missing, f"missing default tools: {sorted(missing)}"
+
+
+def test_default_registry_openai_spec_matches_openai_shape() -> None:
+    from orchestrator.tools._registrations import register_default_tools
+
+    register_default_tools()
+    spec = default_registry.openai_tools_spec()
+    assert spec, "default registry should have tools registered"
+    for entry in spec:
+        assert entry["type"] == "function"
+        fn = entry["function"]
+        assert set(fn) == {"name", "description", "parameters"}
+        assert isinstance(fn["name"], str) and fn["name"]
+        assert isinstance(fn["description"], str)
+        params = fn["parameters"]
+        assert isinstance(params, dict)
+        assert params.get("type") == "object"
+        assert "properties" in params
+
+
+def test_register_default_tools_idempotent() -> None:
+    from orchestrator.tools._registrations import register_default_tools
+
+    register_default_tools()
+    before = set(default_registry.names())
+    register_default_tools()
+    register_default_tools()
+    assert set(default_registry.names()) == before
+
+
+def test_permissions_field_defaults_and_round_trips() -> None:
+    plain = _make_tool()
+    assert plain.permissions == {}
+    perm = _make_tool(name="other.add", permissions={"network": True})
+    assert perm.permissions == {"network": True}
+
+
+def test_dispatch_uses_kwargs() -> None:
+    captured: dict = {}
+
+    def fn(**kwargs: object) -> dict:
+        captured.update(kwargs)
+        return kwargs
+
+    reg = Registry()
+    reg.register(_make_tool(fn=fn))
+    reg.dispatch("math.add", {"a": 7, "b": 9})
+    assert captured == {"a": 7, "b": 9}
+
+
+# -- Browser wrappers (stubbed) -------------------------------------------
+
+
+class _StubBrowser:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    def browse(self, url):
+        self.calls.append(("browse", (url,), {}))
+        return {"url": url, "title": "t", "text": "x", "html_truncated": "", "status": 200}
+
+    def extract(self, url, selector):
+        self.calls.append(("extract", (url, selector), {}))
+        return ["a", "b"]
+
+    def click(self, url, selector):
+        self.calls.append(("click", (url, selector), {}))
+        return {"url": url, "title": "", "text": "", "html_truncated": "", "status": 200}
+
+    def fill(self, url, selector, value):
+        self.calls.append(("fill", (url, selector, value), {}))
+        return {"url": url, "title": "", "text": "", "html_truncated": "", "status": 200}
+
+
+def _install_stub_browser(monkeypatch: pytest.MonkeyPatch) -> _StubBrowser:
+    from orchestrator.tools import _registrations
+
+    stub = _StubBrowser()
+    monkeypatch.setattr(_registrations, "_browser_singleton", stub, raising=True)
+    return stub
+
+
+def test_browser_browse_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _install_stub_browser(monkeypatch)
+    result = default_registry.dispatch("browser.browse", {"url": "https://example.com"})
+    assert result.ok is True
+    assert stub.calls[0][0] == "browse"
+
+
+def test_browser_extract_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _install_stub_browser(monkeypatch)
+    result = default_registry.dispatch(
+        "browser.extract", {"url": "https://example.com", "selector": "h1"}
+    )
+    assert result.ok is True
+    assert result.data == ["a", "b"]
+    assert stub.calls[0][0] == "extract"
+
+
+def test_browser_click_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _install_stub_browser(monkeypatch)
+    result = default_registry.dispatch(
+        "browser.click", {"url": "https://example.com", "selector": "button"}
+    )
+    assert result.ok is True
+    assert stub.calls[0][0] == "click"
+
+
+def test_browser_fill_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _install_stub_browser(monkeypatch)
+    result = default_registry.dispatch(
+        "browser.fill",
+        {"url": "https://example.com", "selector": "#q", "value": "hi"},
+    )
+    assert result.ok is True
+    assert stub.calls[0][0] == "fill"
+
+
+def test_get_browser_lazy_instantiates(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.tools import _registrations
+    from orchestrator.tools import browser as browser_mod
+
+    monkeypatch.setattr(_registrations, "_browser_singleton", None, raising=True)
+    instances: list[object] = []
+
+    class _Fake:
+        def __init__(self) -> None:
+            instances.append(self)
+
+    monkeypatch.setattr(browser_mod, "BrowserTool", _Fake)
+    inst = _registrations._get_browser()
+    again = _registrations._get_browser()
+    assert inst is again
+    assert len(instances) == 1
+
+
+# --- Tests merged from main (PR #75 minimal-registry surface) ---
 def _tool(name: str, source: str = "builtin") -> Tool:
     return Tool(name=name, description="", parameters_schema={}, source=source)
 


### PR DESCRIPTION
Closes #30

## Summary
Adds the OpenAI-style tool registry that bridges the coder model's function calls to the Phase 4 tool implementations.

- `orchestrator/tools/registry.py` — Pydantic `Tool` (name, description, `parameters_schema`, `fn`, optional `permissions`) and `ToolResult` (`ok`, `data`, `error`, `duration_ms`) plus a `Registry` class with `register`, `dispatch`, `openai_tools_spec`, and a module-level `default_registry` singleton.
- Validation: schemas are checked at registration with `jsonschema.Draft202012Validator.check_schema`; arguments are validated against the tool's `parameters_schema` before the callable runs. `dispatch` always returns a `ToolResult` and never lets an exception escape; timing is populated on every path.
- `openai_tools_spec()` returns `[{"type": "function", "function": {"name", "description", "parameters"}}, ...]` ready to pass to `chat.completions.create(tools=...)`.
- `orchestrator/tools/_registrations.py` — thin shim that wraps each Phase 4 tool's public functions (`fs`, `shell`, `web`, `git`, `browser`) with hand-written OpenAI-compatible JSON Schemas and registers them on `default_registry`. Tool source files are unchanged. Imported from `orchestrator/tools/__init__.py` so `import orchestrator.tools` populates the registry.
- `pyproject.toml` — adds `jsonschema>=4.21`.

## Tests
`tests/tools/test_registry.py` covers register + lookup, duplicate-name rejection, invalid-schema rejection, dispatch happy path, unknown tool, schema-invalid args (callable never invoked), captured `fn` exceptions wrapped into the envelope, timing populated even on failure, sorted listing, OpenAI spec shape, idempotent default registration, and stubbed browser wrappers. New modules at 100 % line coverage.

## Verification
- `ruff check .` → clean
- `pytest -q` → 111 passed, 1 skipped
- `pytest tests/tools/test_registry.py --cov=orchestrator.tools.registry --cov=orchestrator.tools._registrations` → 100 % on both new modules

## Acceptance Criteria met
- [x] `Tool` Pydantic model with `name/description/parameters_schema/fn` (+ `arbitrary_types_allowed` for the callable) and `ToolResult { ok, data, error, duration_ms }`.
- [x] `parameters_schema` is OpenAI-function-calling-compatible JSON Schema (object with `properties`, `required`).
- [x] `Registry.register` rejects duplicates by name.
- [x] `Registry.dispatch` validates args via `jsonschema`, invokes `fn(**args)`, captures exceptions into `ToolResult(ok=False, error=...)`, and times the call in milliseconds.
- [x] `Registry.openai_tools_spec()` returns the documented OpenAI shape.
- [x] Module-level `default_registry` singleton exported.
- [x] Each Phase 4 tool module's public functions are registered on the default registry at `orchestrator.tools` import time with hand-written JSON Schemas.
- [x] Schemas are sanity-checked at registration with `Draft202012Validator.check_schema`.
- [x] Tests cover happy path + duplicate registration + unknown tool + schema-invalid args + raised exception + timing + spec shape.
