### PR TITLE
ops: add Makefile, pre-commit, editorconfig, mypy strict, dev scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_size = 4
+
+[*.{yml,yaml,json,md}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,3 @@ test-results/
 # Agent scratch dirs (temp issue bodies created during bootstrap)
 .tmp-issues/
 .issue-bodies/
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        exclude: '^\.github/ISSUE_TEMPLATE/.*\.ya?ml$'
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: help install lint format test cov precommit clean serve
+
+.DEFAULT_GOAL := help
+
+help: ## Show this help message
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install: ## Install package with dev extras and pre-commit hooks
+	python -m pip install --upgrade pip
+	pip install -e ".[dev]"
+	pre-commit install --install-hooks
+
+lint: ## Run ruff lint and format check
+	ruff check .
+	ruff format --check .
+
+format: ## Auto-format with ruff
+	ruff format .
+	ruff check --fix .
+
+test: ## Run the test suite
+	pytest -q
+
+cov: ## Run tests with coverage gate (>=95%)
+	pytest --cov=orchestrator --cov-report=term-missing --cov-fail-under=95
+
+precommit: ## Run pre-commit on all files
+	pre-commit run --all-files
+
+clean: ## Remove caches and build artifacts
+	rm -rf .pytest_cache .ruff_cache .mypy_cache .coverage htmlcov build dist *.egg-info
+	find . -type d -name __pycache__ -exec rm -rf {} +
+
+serve: ## Run the orchestrator CLI (placeholder)
+	python -m orchestrator

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,78 @@
+# Development Guide
+
+This guide describes how to set up a local development environment and the
+common workflows for working on the orchestrator.
+
+## Prerequisites
+
+- Python 3.11 or newer
+- `git` with commit signing configured (the repo enforces signed commits)
+- GNU Make (optional but recommended)
+
+## One-line bootstrap
+
+From a fresh clone:
+
+```bash
+# macOS / Linux
+./scripts/dev_setup.sh
+```
+
+```powershell
+# Windows PowerShell
+.\scripts\dev_setup.ps1
+```
+
+The script creates a `.venv`, installs the package in editable mode with the
+`dev` extras, and installs the pre-commit hooks.
+
+## Manual setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate            # Windows: .\.venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
+pre-commit install --install-hooks
+```
+
+## Common Makefile targets
+
+| Target          | What it does                                       |
+| --------------- | -------------------------------------------------- |
+| `make help`     | List all available targets (default).              |
+| `make install`  | Install dev deps and pre-commit hooks.             |
+| `make lint`     | Run `ruff check` and `ruff format --check`.        |
+| `make format`   | Auto-format and apply safe lint fixes.             |
+| `make test`     | Run the test suite.                                |
+| `make cov`      | Run tests with the 95% coverage gate.              |
+| `make precommit`| Run all pre-commit hooks across the repo.          |
+| `make clean`    | Remove caches and build artifacts.                 |
+
+## Pre-commit hooks
+
+Configured in `.pre-commit-config.yaml`:
+
+- `pre-commit-hooks`: trailing whitespace, EOF fixer, YAML / TOML / merge
+  conflict / large file checks.
+- `ruff`: lint (with `--fix`) and format.
+- `gitleaks`: scan for accidentally committed secrets.
+
+Run them on demand with:
+
+```bash
+pre-commit run --all-files
+```
+
+## Type checking
+
+`mypy` is configured in strict mode for the `orchestrator/` package; tests and
+helper scripts under `.github/scripts/` are excluded. Run it with:
+
+```bash
+mypy orchestrator
+```
+
+## Editor configuration
+
+`.editorconfig` enforces UTF-8, LF line endings, trimmed trailing whitespace,
+4-space indentation for Python and 2-space indentation for YAML / JSON / MD.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "ruff>=0.6",
     "mypy>=1.10",
     "respx>=0.21",
+    "pre-commit>=3.7",
 ]
 browser = [
     "playwright>=1.40",
@@ -72,6 +73,27 @@ extend-exclude = [".github/scripts"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "W", "SIM", "RUF"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_unused_ignores = true
+no_implicit_optional = true
+exclude = [
+    "tests/",
+    "\\.github/scripts/",
+    "build/",
+    "dist/",
+]
+
+[[tool.mypy.overrides]]
+module = [
+    "duckduckgo_search.*",
+    "selectolax.*",
+    "psutil.*",
+    "respx.*",
+]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/dev_setup.ps1
+++ b/scripts/dev_setup.ps1
@@ -1,0 +1,9 @@
+#!/usr/bin/env pwsh
+# Bootstrap a local development environment.
+$ErrorActionPreference = "Stop"
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install -e ".[dev]"
+pre-commit install --install-hooks
+Write-Host "Dev environment ready. Activate with: .\.venv\Scripts\Activate.ps1"

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Bootstrap a local development environment.
+set -euo pipefail
+python -m venv .venv
+# shellcheck disable=SC1091
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -e ".[dev]"
+pre-commit install --install-hooks
+echo "Dev environment ready. Activate with: source .venv/bin/activate"


### PR DESCRIPTION
## Summary
Adds the remaining build-tooling pieces from issue #51 that were not landed in PR #70 (which already provided pyproject + ruff + pytest + coverage on main).

## Changes
- `Makefile` — targets: `install`, `lint`, `format`, `test`, `cov`, `precommit`, `clean`, `serve`, `help` (default, self-documenting).
- `.pre-commit-config.yaml` — pinned `pre-commit-hooks` (trailing-whitespace, end-of-file-fixer, check-yaml, check-toml, check-merge-conflict, check-added-large-files), `ruff` (lint + format), `gitleaks`. `check-yaml` excludes `.github/ISSUE_TEMPLATE/*.yml` because GitHub issue forms use a syntax pyyaml's safe loader rejects.
- `.editorconfig` — root, UTF-8, LF, trim trailing ws, 4-space Python, 2-space YAML/JSON/MD, tab for Makefile.
- `pyproject.toml` — adds `[tool.mypy]` strict config (`strict = true`, `python_version = "3.11"`, excludes `tests/` and `.github/scripts/`, override block for un-typed deps); adds `pre-commit` to `[project.optional-dependencies].dev`.
- `scripts/dev_setup.ps1` + `scripts/dev_setup.sh` — one-line venv + install + `pre-commit install` bootstrap.
- `docs/DEVELOPMENT.md` — dev environment setup, common Makefile targets, pre-commit, mypy.

## Verification
- `ruff check . && ruff format --check .` ✅
- `pre-commit run --all-files` ✅ (all 9 hooks pass)
- `pytest --cov=orchestrator --cov-fail-under=95 -q` ✅ — 123 passed, 1 skipped, **coverage 99.37%**
- Commit is GPG-signed (`%G? = G`).

Closes #51

Acceptance Criteria met.
