### PR TITLE
feat(tools): config-driven MCP client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ logs/
 .env.local
 secrets.toml
 
+# User-supplied MCP client configuration (see config/mcp_servers.yaml.example)
+config/mcp_servers.yaml
+
 # Playwright / browsers
 .playwright/
 playwright-report/

--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ This project is **agent-friendly**: every issue contains enough context, accepta
 
 Mac M1 Pro, 16 GB RAM. Designed to never exceed ~11 GB resident.
 
+## Wiring external MCP servers
+
+The orchestrator can consume any number of remote/cloud MCP servers as
+local tools. Copy the example config and edit it:
+
+```bash
+cp config/mcp_servers.yaml.example config/mcp_servers.yaml
+# edit config/mcp_servers.yaml — supports stdio | http | sse transports
+orchestrator mcp list      # show connected servers + tool counts
+orchestrator mcp reload    # re-read the config without restarting
+```
+
+Environment variables in the config (e.g. `${GITHUB_TOKEN}`) are expanded
+at load time, so secrets stay out of source control.
+
 ## License
 
 Licensed under the **Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License** ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)).

--- a/config/mcp_servers.yaml.example
+++ b/config/mcp_servers.yaml.example
@@ -1,0 +1,23 @@
+# Example MCP server configuration consumed by orchestrator.tools.mcp_client.
+#
+# Copy this file to config/mcp_servers.yaml (gitignored) and edit the
+# entries to match the MCP servers you want the orchestrator to surface
+# as local tools. Environment variables are expanded with ${VAR} syntax.
+servers:
+  - name: github
+    enabled: true
+    transport: stdio          # stdio | http | sse
+    command: ["npx", "-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_TOKEN}
+    timeout_s: 30
+    tool_prefix: github_      # avoid name collisions
+
+  - name: context7
+    enabled: false
+    transport: http
+    url: https://mcp.context7.com/mcp
+    headers:
+      Authorization: Bearer ${CONTEXT7_KEY}
+    timeout_s: 20
+    tool_prefix: ctx7_

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -125,6 +125,9 @@ orchestrator/
 - `web` (fetch + search via DuckDuckGo/Brave API)
 - `browser` (Playwright, separate process)
 - `git` (local repo ops)
+- **MCP client** — config-driven loader (`config/mcp_servers.yaml`) that
+  surfaces tools from any number of remote/cloud MCP servers (GitHub,
+  Atlassian, Context7, …) through the same registry as the built-in tools
 - Tool schemas exposed to coder model in OpenAI-style function-calling format
 
 ### Phase 5 — Interfaces

--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -1,0 +1,99 @@
+"""Console entry point for the orchestrator.
+
+Currently exposes the ``mcp`` subcommands needed by issue #45:
+
+* ``orchestrator mcp list`` — print every configured MCP server, its
+  transport, status, and the number of tools it exposes.
+* ``orchestrator mcp reload`` — re-read the MCP config file without
+  restarting any longer-running process (in single-shot CLI mode this
+  simply demonstrates the reload codepath against a fresh manager).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TextIO
+
+from orchestrator.core.logging import configure_logging
+from orchestrator.tools.mcp_client import MCPClientError, MCPManager, SessionFactory
+
+__all__ = ["build_parser", "main", "run_mcp_command"]
+
+DEFAULT_CONFIG = Path("config/mcp_servers.yaml")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="orchestrator")
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (default: INFO).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    mcp = sub.add_parser("mcp", help="Manage MCP server connections.")
+    mcp_sub = mcp.add_subparsers(dest="mcp_command", required=True)
+
+    for name, help_text in (
+        ("list", "List configured MCP servers and their tool counts."),
+        ("reload", "Re-read the MCP config and reconnect changed servers."),
+    ):
+        sp = mcp_sub.add_parser(name, help=help_text)
+        sp.add_argument(
+            "--config",
+            type=Path,
+            default=DEFAULT_CONFIG,
+            help=f"Path to MCP config YAML (default: {DEFAULT_CONFIG}).",
+        )
+    return parser
+
+
+async def run_mcp_command(
+    action: str,
+    config_path: Path,
+    *,
+    session_factory: SessionFactory | None = None,
+    out: TextIO | None = None,
+) -> int:
+    """Execute ``mcp list`` or ``mcp reload``; return process exit code."""
+    stream = out if out is not None else sys.stdout
+    manager = MCPManager(config_path, session_factory=session_factory)
+    try:
+        await manager.start()
+        if action == "reload":
+            await manager.reload()
+        statuses = manager.list_status()
+        if not statuses:
+            print("(no MCP servers configured)", file=stream)
+        else:
+            for status in statuses:
+                state = "ok" if status.connected else (status.error or "down")
+                print(
+                    f"{status.name}\t{status.transport}\t{state}\t"
+                    f"tools={status.tool_count}\tprefix={status.tool_prefix!r}",
+                    file=stream,
+                )
+        return 0
+    except MCPClientError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    finally:
+        await manager.aclose()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(level=args.log_level)
+    if args.command == "mcp":
+        return asyncio.run(run_mcp_command(args.mcp_command, args.config))
+    parser.error(f"unknown command: {args.command}")  # pragma: no cover
+    return 2  # pragma: no cover
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/orchestrator/tools/__init__.py
+++ b/orchestrator/tools/__init__.py
@@ -1,13 +1,24 @@
-"""Tool implementations callable by the orchestrator."""
+"""Tool implementations callable by the orchestrator.
+
+Built-in tools are imported eagerly. The MCP client (which surfaces
+remote tools through :class:`~orchestrator.tools.mcp_client.MCPManager`)
+is wired up lazily by callers that have a config path — see
+``orchestrator.cli`` and ``docs/PLAN.md`` for the wiring.
+"""
 
 from ._sandbox import WorkspaceEscapeError, resolve_in_workspace
 from .fs import delete_file, list_dir, read_file, write_file
+from .registry import Registry, Tool, ToolResult, default_registry
 from .shell import CommandResult, DeniedCommandError, run_command
 
 __all__ = [
     "CommandResult",
     "DeniedCommandError",
+    "Registry",
+    "Tool",
+    "ToolResult",
     "WorkspaceEscapeError",
+    "default_registry",
     "delete_file",
     "list_dir",
     "read_file",

--- a/orchestrator/tools/mcp_client.py
+++ b/orchestrator/tools/mcp_client.py
@@ -1,0 +1,448 @@
+"""Config-driven MCP client.
+
+Reads a YAML config of MCP servers, opens a :class:`mcp.ClientSession`
+for each enabled entry, and registers the remote tools as local
+:class:`~orchestrator.tools.registry.Tool` entries.
+
+The default session factory is a thin wrapper over the official ``mcp``
+SDK; tests inject a fake factory so no real subprocess or HTTP traffic
+is ever generated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import time
+from collections.abc import Awaitable, Callable
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+import structlog
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from .registry import Registry, Tool, ToolResult, default_registry
+
+__all__ = [
+    "MCPClientError",
+    "MCPManager",
+    "ServerSpec",
+    "ServerStatus",
+    "SessionFactory",
+    "default_session_factory",
+    "expand_env",
+    "load_config",
+]
+
+log = structlog.get_logger("orchestrator.tools.mcp_client")
+
+_ENV_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+TOOL_SOURCE = "mcp"
+
+
+class MCPClientError(RuntimeError):
+    """Raised for invalid MCP client configuration."""
+
+
+class ServerSpec(BaseModel):
+    """Configuration for a single MCP server entry."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(min_length=1)
+    enabled: bool = True
+    transport: Literal["stdio", "http", "sse"]
+    command: tuple[str, ...] | None = None
+    url: str | None = None
+    env: dict[str, str] = Field(default_factory=dict)
+    headers: dict[str, str] = Field(default_factory=dict)
+    timeout_s: float = Field(default=30.0, gt=0)
+    tool_prefix: str = ""
+
+    @model_validator(mode="after")
+    def _check_transport_args(self) -> ServerSpec:
+        if self.transport == "stdio":
+            if not self.command:
+                raise ValueError("stdio transport requires a non-empty 'command'")
+            if self.url is not None:
+                raise ValueError("stdio transport must not set 'url'")
+        else:
+            if not self.url:
+                raise ValueError(f"{self.transport} transport requires 'url'")
+            if self.command is not None:
+                raise ValueError(f"{self.transport} transport must not set 'command'")
+        return self
+
+
+def expand_env(value: Any, environ: dict[str, str] | None = None) -> Any:
+    """Recursively substitute ``${VAR}`` tokens using ``environ``.
+
+    Strings, lists, tuples and dicts are walked. Missing variables expand
+    to the empty string (matching common shell semantics) so a partially
+    configured environment still produces a structurally valid config.
+    """
+    env = environ if environ is not None else os.environ
+
+    if isinstance(value, str):
+        return _ENV_PATTERN.sub(lambda m: env.get(m.group(1), ""), value)
+    if isinstance(value, list):
+        return [expand_env(v, env) for v in value]
+    if isinstance(value, tuple):
+        return tuple(expand_env(v, env) for v in value)
+    if isinstance(value, dict):
+        return {k: expand_env(v, env) for k, v in value.items()}
+    return value
+
+
+def load_config(path: str | Path, environ: dict[str, str] | None = None) -> list[ServerSpec]:
+    """Parse ``path`` and return the validated list of :class:`ServerSpec`.
+
+    Raises:
+        MCPClientError: File missing, invalid YAML, or schema violation.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise MCPClientError(f"MCP config not found: {p}")
+    try:
+        raw = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise MCPClientError(f"Invalid YAML in {p}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise MCPClientError(f"Top-level YAML in {p} must be a mapping")
+    servers_raw = raw.get("servers", [])
+    if not isinstance(servers_raw, list):
+        raise MCPClientError("'servers' must be a list")
+
+    expanded = expand_env(servers_raw, environ)
+    specs: list[ServerSpec] = []
+    seen: set[str] = set()
+    for entry in expanded:
+        if not isinstance(entry, dict):
+            raise MCPClientError("each server entry must be a mapping")
+        try:
+            spec = ServerSpec.model_validate(entry)
+        except ValidationError as exc:
+            raise MCPClientError(f"invalid server spec: {exc}") from exc
+        if spec.name in seen:
+            raise MCPClientError(f"duplicate server name: {spec.name}")
+        seen.add(spec.name)
+        specs.append(spec)
+    return specs
+
+
+class SessionLike(Protocol):
+    """Minimal subset of ``mcp.ClientSession`` we depend on."""
+
+    async def list_tools(self) -> Any: ...
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any: ...
+
+
+SessionFactory = Callable[
+    [ServerSpec, AsyncExitStack],
+    Awaitable[SessionLike],
+]
+
+
+async def default_session_factory(
+    spec: ServerSpec,
+    stack: AsyncExitStack,
+) -> SessionLike:  # pragma: no cover - exercised only against real MCP servers
+    """Build a real :class:`mcp.ClientSession` for ``spec``.
+
+    This is intentionally excluded from coverage: tests inject a fake
+    session factory so no subprocesses or network connections are made.
+    """
+    from mcp import ClientSession
+
+    if spec.transport == "stdio":
+        from mcp import StdioServerParameters
+        from mcp.client.stdio import stdio_client
+
+        if not spec.command:
+            raise MCPClientError(f"stdio server {spec.name!r} has no command")
+        params = StdioServerParameters(
+            command=spec.command[0],
+            args=list(spec.command[1:]),
+            env=dict(spec.env) or None,
+        )
+        read, write = await stack.enter_async_context(stdio_client(params))
+    elif spec.transport == "sse":
+        from mcp.client.sse import sse_client
+
+        read, write = await stack.enter_async_context(
+            sse_client(spec.url, headers=dict(spec.headers) or None)
+        )
+    else:  # http (streamable HTTP)
+        from mcp.client.streamable_http import streamablehttp_client
+
+        read, write, _ = await stack.enter_async_context(
+            streamablehttp_client(spec.url, headers=dict(spec.headers) or None)
+        )
+
+    session = await stack.enter_async_context(ClientSession(read, write))
+    await session.initialize()
+    return session
+
+
+@dataclass(slots=True)
+class ServerStatus:
+    """Runtime view of a connected (or skipped) MCP server."""
+
+    name: str
+    transport: str
+    connected: bool
+    tool_count: int
+    tool_prefix: str
+    error: str | None = None
+    tools: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class _Connection:
+    spec: ServerSpec
+    session: SessionLike
+    stack: AsyncExitStack
+    tool_names: list[str]
+
+
+def _content_to_text(content: Any) -> str:
+    """Best-effort extraction of plain text from MCP content blocks."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            text = getattr(item, "text", None)
+            if text is None and isinstance(item, dict):
+                text = item.get("text")
+            if text is not None:
+                parts.append(str(text))
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+    return str(content)
+
+
+class MCPManager:
+    """Owns the lifecycle of all configured MCP server sessions."""
+
+    def __init__(
+        self,
+        config_path: str | Path,
+        *,
+        registry: Registry | None = None,
+        session_factory: SessionFactory | None = None,
+        environ: dict[str, str] | None = None,
+    ) -> None:
+        self._path = Path(config_path)
+        self._registry = registry if registry is not None else default_registry
+        self._session_factory = session_factory or default_session_factory
+        self._environ = environ
+        self._connections: dict[str, _Connection] = {}
+        self._statuses: dict[str, ServerStatus] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def config_path(self) -> Path:
+        return self._path
+
+    async def start(self) -> None:
+        """Load config and connect every enabled server."""
+        async with self._lock:
+            specs = load_config(self._path, self._environ)
+            self._statuses = {}
+            for spec in specs:
+                if not spec.enabled:
+                    self._statuses[spec.name] = ServerStatus(
+                        name=spec.name,
+                        transport=spec.transport,
+                        connected=False,
+                        tool_count=0,
+                        tool_prefix=spec.tool_prefix,
+                        error="disabled",
+                    )
+                    continue
+                await self._connect_locked(spec)
+
+    async def reload(self) -> None:
+        """Re-read the config; close removed servers, open new ones."""
+        async with self._lock:
+            new_specs = load_config(self._path, self._environ)
+            new_by_name = {s.name: s for s in new_specs}
+
+            for name in list(self._connections):
+                spec = new_by_name.get(name)
+                if spec is None or not spec.enabled or spec != self._connections[name].spec:
+                    await self._disconnect_locked(name)
+
+            new_statuses: dict[str, ServerStatus] = {}
+            for spec in new_specs:
+                if not spec.enabled:
+                    new_statuses[spec.name] = ServerStatus(
+                        name=spec.name,
+                        transport=spec.transport,
+                        connected=False,
+                        tool_count=0,
+                        tool_prefix=spec.tool_prefix,
+                        error="disabled",
+                    )
+                    continue
+                if spec.name in self._connections:
+                    new_statuses[spec.name] = self._statuses[spec.name]
+                    continue
+                await self._connect_locked(spec)
+                new_statuses[spec.name] = self._statuses[spec.name]
+            self._statuses = new_statuses
+
+    async def aclose(self) -> None:
+        """Tear down every active connection."""
+        async with self._lock:
+            for name in list(self._connections):
+                await self._disconnect_locked(name)
+
+    def list_status(self) -> list[ServerStatus]:
+        """Snapshot of every configured server."""
+        return list(self._statuses.values())
+
+    async def _connect_locked(self, spec: ServerSpec) -> None:
+        stack = AsyncExitStack()
+        await stack.__aenter__()
+        try:
+            session = await self._session_factory(spec, stack)
+            tools_resp = await session.list_tools()
+            remote_tools = list(getattr(tools_resp, "tools", tools_resp) or [])
+        except Exception as exc:
+            await stack.aclose()
+            log.warning(
+                "mcp.server.unreachable",
+                server=spec.name,
+                transport=spec.transport,
+                error=str(exc),
+            )
+            self._statuses[spec.name] = ServerStatus(
+                name=spec.name,
+                transport=spec.transport,
+                connected=False,
+                tool_count=0,
+                tool_prefix=spec.tool_prefix,
+                error=str(exc),
+            )
+            return
+
+        registered: list[str] = []
+        for remote in remote_tools:
+            remote_name = getattr(remote, "name", None) or remote["name"]
+            description = getattr(remote, "description", None)
+            if description is None and isinstance(remote, dict):
+                description = remote.get("description")
+            input_schema = getattr(remote, "inputSchema", None)
+            if input_schema is None and isinstance(remote, dict):
+                input_schema = remote.get("inputSchema")
+            local_name = f"{spec.tool_prefix}{remote_name}"
+            tool = Tool(
+                name=local_name,
+                description=description or "",
+                parameters_schema=dict(input_schema or {}),
+                fn=self._make_dispatcher(spec, session, remote_name),
+                source=TOOL_SOURCE,
+            )
+            self._registry.register(tool, replace=True)
+            registered.append(local_name)
+
+        self._connections[spec.name] = _Connection(
+            spec=spec, session=session, stack=stack, tool_names=registered
+        )
+        self._statuses[spec.name] = ServerStatus(
+            name=spec.name,
+            transport=spec.transport,
+            connected=True,
+            tool_count=len(registered),
+            tool_prefix=spec.tool_prefix,
+            tools=list(registered),
+        )
+        log.info(
+            "mcp.server.connected",
+            server=spec.name,
+            transport=spec.transport,
+            tools=len(registered),
+        )
+
+    async def _disconnect_locked(self, name: str) -> None:
+        conn = self._connections.pop(name, None)
+        if conn is None:
+            return
+        for tool_name in conn.tool_names:
+            self._registry.unregister(tool_name)
+        try:
+            await conn.stack.aclose()
+        except Exception as exc:
+            log.warning("mcp.server.close_error", server=name, error=str(exc))
+        log.info("mcp.server.disconnected", server=name)
+
+    def _make_dispatcher(
+        self,
+        spec: ServerSpec,
+        session: SessionLike,
+        remote_name: str,
+    ) -> Callable[..., Awaitable[ToolResult]]:
+        async def _dispatch(**args: Any) -> ToolResult:
+            t0 = time.monotonic()
+            log.debug(
+                "mcp.tool.args",
+                server=spec.name,
+                tool=remote_name,
+                args=args,
+            )
+            try:
+                result = await asyncio.wait_for(
+                    session.call_tool(remote_name, args),
+                    timeout=spec.timeout_s,
+                )
+            except TimeoutError:
+                duration = time.monotonic() - t0
+                log.info(
+                    "mcp.tool.call",
+                    server=spec.name,
+                    tool=remote_name,
+                    ok=False,
+                    duration=duration,
+                    error="timeout",
+                )
+                return ToolResult(
+                    ok=False,
+                    error=f"timeout after {spec.timeout_s}s",
+                )
+            except Exception as exc:
+                duration = time.monotonic() - t0
+                log.info(
+                    "mcp.tool.call",
+                    server=spec.name,
+                    tool=remote_name,
+                    ok=False,
+                    duration=duration,
+                    error=str(exc),
+                )
+                return ToolResult(ok=False, error=str(exc))
+
+            duration = time.monotonic() - t0
+            content = getattr(result, "content", None)
+            is_error = bool(getattr(result, "isError", False))
+            text = _content_to_text(content)
+            log.info(
+                "mcp.tool.call",
+                server=spec.name,
+                tool=remote_name,
+                ok=not is_error,
+                duration=duration,
+            )
+            if is_error:
+                return ToolResult(ok=False, error=text or "tool reported error")
+            return ToolResult(ok=True, content=text)
+
+        return _dispatch

--- a/orchestrator/tools/registry.py
+++ b/orchestrator/tools/registry.py
@@ -1,0 +1,97 @@
+"""Minimal in-process tool registry.
+
+Provides the ``Tool`` / ``ToolResult`` data types and a thread-safe
+``Registry`` that maps tool names to async callables. The MCP client
+(:mod:`orchestrator.tools.mcp_client`) uses this registry to surface
+remote MCP tools alongside built-in tools.
+
+This is a lightweight stand-in for the richer registry tracked in
+issue #30; the public surface (``register`` / ``unregister`` / ``get``
+/ ``names``) is kept small and stable so the larger registry can drop
+in without breaking callers.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "Registry",
+    "Tool",
+    "ToolResult",
+    "default_registry",
+]
+
+
+@dataclass(slots=True)
+class ToolResult:
+    """Standard envelope returned by every tool dispatch."""
+
+    ok: bool
+    content: Any = None
+    error: str | None = None
+
+
+@dataclass(slots=True)
+class Tool:
+    """A registered tool callable by the orchestrator."""
+
+    name: str
+    description: str
+    parameters_schema: dict[str, Any] = field(default_factory=dict)
+    fn: Callable[..., Awaitable[ToolResult]] | None = None
+    source: str = "builtin"
+
+
+class Registry:
+    """In-process map of tool name → :class:`Tool`."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, Tool] = {}
+        self._lock = threading.RLock()
+
+    def register(self, tool: Tool, *, replace: bool = False) -> None:
+        """Add ``tool`` to the registry.
+
+        Raises:
+            ValueError: When a tool with the same name already exists and
+                ``replace`` is ``False``.
+        """
+        with self._lock:
+            if tool.name in self._tools and not replace:
+                raise ValueError(f"tool {tool.name!r} already registered")
+            self._tools[tool.name] = tool
+
+    def unregister(self, name: str) -> None:
+        with self._lock:
+            self._tools.pop(name, None)
+
+    def get(self, name: str) -> Tool:
+        with self._lock:
+            return self._tools[name]
+
+    def names(self) -> list[str]:
+        with self._lock:
+            return sorted(self._tools)
+
+    def by_source(self, source: str) -> list[Tool]:
+        with self._lock:
+            return [t for t in self._tools.values() if t.source == source]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._tools.clear()
+
+    def __contains__(self, name: object) -> bool:
+        with self._lock:
+            return name in self._tools
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._tools)
+
+
+default_registry = Registry()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,12 @@ dependencies = [
     "httpx>=0.27",
     "selectolax>=0.3.21",
     "duckduckgo-search>=6.0",
+    "mcp>=1.0,<2",
+    "pyyaml>=6.0",
 ]
+
+[project.scripts]
+orchestrator = "orchestrator.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,116 @@
+"""Tests for the orchestrator CLI."""
+
+from __future__ import annotations
+
+import io
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator import cli
+from orchestrator.tools.mcp_client import ServerSpec
+from tests.tools.test_mcp_client import FakeSession, _FakeTool
+
+
+def _write_cfg(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "mcp.yaml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _factory(sessions: dict[str, FakeSession]):
+    async def _f(spec: ServerSpec, stack: AsyncExitStack) -> FakeSession:
+        sess = sessions[spec.name]
+
+        async def _close() -> None:
+            sess.closed = True
+
+        stack.push_async_callback(_close)
+        return sess
+
+    return _f
+
+
+def test_build_parser_requires_subcommand(capsys: pytest.CaptureFixture[str]) -> None:
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+    captured = capsys.readouterr()
+    assert "command" in captured.err.lower() or "usage" in captured.err.lower()
+
+
+def test_run_mcp_list_prints_status(tmp_path: Path) -> None:
+    cfg = _write_cfg(
+        tmp_path,
+        "servers:\n"
+        "  - name: a\n    enabled: true\n    transport: stdio\n"
+        "    command: [echo]\n    tool_prefix: 'a_'\n    timeout_s: 1\n"
+        "  - name: b\n    enabled: false\n    transport: stdio\n"
+        "    command: [echo]\n    tool_prefix: ''\n    timeout_s: 1\n",
+    )
+    sessions = {"a": FakeSession(tools=[_FakeTool("ping")])}
+    buf = io.StringIO()
+    import asyncio
+
+    rc = asyncio.run(cli.run_mcp_command("list", cfg, session_factory=_factory(sessions), out=buf))
+    assert rc == 0
+    output = buf.getvalue()
+    assert "a\tstdio\tok\ttools=1" in output
+    assert "b\tstdio\tdisabled\ttools=0" in output
+
+
+def test_run_mcp_reload_prints_status(tmp_path: Path) -> None:
+    cfg = _write_cfg(
+        tmp_path,
+        "servers:\n"
+        "  - name: a\n    enabled: true\n    transport: stdio\n"
+        "    command: [echo]\n    tool_prefix: 'a_'\n    timeout_s: 1\n",
+    )
+    sessions = {"a": FakeSession(tools=[_FakeTool("ping")])}
+    buf = io.StringIO()
+    import asyncio
+
+    rc = asyncio.run(
+        cli.run_mcp_command("reload", cfg, session_factory=_factory(sessions), out=buf)
+    )
+    assert rc == 0
+    assert "a\tstdio\tok" in buf.getvalue()
+
+
+def test_run_mcp_list_handles_missing_config(tmp_path: Path) -> None:
+    import asyncio
+
+    rc = asyncio.run(cli.run_mcp_command("list", tmp_path / "nope.yaml"))
+    assert rc == 2
+
+
+def test_run_mcp_list_handles_empty_config(tmp_path: Path) -> None:
+    cfg = _write_cfg(tmp_path, "servers: []\n")
+    buf = io.StringIO()
+    import asyncio
+
+    rc = asyncio.run(cli.run_mcp_command("list", cfg, out=buf))
+    assert rc == 0
+    assert "no MCP servers" in buf.getvalue()
+
+
+def test_main_dispatches_to_mcp_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cfg = _write_cfg(tmp_path, "servers: []\n")
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run(action: str, path: Path) -> int:
+        captured["action"] = action
+        captured["path"] = path
+        return 0
+
+    monkeypatch.setattr(cli, "run_mcp_command", fake_run)
+    rc = cli.main(["mcp", "list", "--config", str(cfg)])
+    assert rc == 0
+    assert captured == {"action": "list", "path": cfg}

--- a/tests/tools/test_mcp_client.py
+++ b/tests/tools/test_mcp_client.py
@@ -1,0 +1,633 @@
+"""Tests for the config-driven MCP client (issue #45).
+
+A tiny in-process fake MCP session is injected via ``session_factory``
+so tests never spawn subprocesses or touch the network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.tools.mcp_client import (
+    MCPClientError,
+    MCPManager,
+    ServerSpec,
+    expand_env,
+    load_config,
+)
+from orchestrator.tools.registry import Registry
+
+# --------------------------------------------------------------------------- #
+# Fake MCP session
+# --------------------------------------------------------------------------- #
+
+
+class _FakeTool:
+    def __init__(self, name: str, description: str = "", schema: dict | None = None) -> None:
+        self.name = name
+        self.description = description
+        self.inputSchema = schema or {"type": "object", "properties": {}}
+
+
+class _FakeContent:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.type = "text"
+
+
+class _FakeResult:
+    def __init__(self, text: str = "", *, is_error: bool = False) -> None:
+        self.content = [_FakeContent(text)] if text else []
+        self.isError = is_error
+
+
+class _FakeListToolsResp:
+    def __init__(self, tools: list[_FakeTool]) -> None:
+        self.tools = tools
+
+
+class FakeSession:
+    """A tiny stand-in for ``mcp.ClientSession``.
+
+    Behaviour can be tuned per-instance: tool listing, per-tool replies,
+    delays, and exceptions all configurable.
+    """
+
+    def __init__(
+        self,
+        tools: list[_FakeTool] | None = None,
+        *,
+        replies: dict[str, Any] | None = None,
+        list_error: Exception | None = None,
+        call_delays: dict[str, float] | None = None,
+    ) -> None:
+        self._tools = tools or []
+        self._replies = replies or {}
+        self._list_error = list_error
+        self._call_delays = call_delays or {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.closed = False
+
+    async def list_tools(self) -> _FakeListToolsResp:
+        if self._list_error is not None:
+            raise self._list_error
+        return _FakeListToolsResp(self._tools)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+        self.calls.append((name, arguments))
+        delay = self._call_delays.get(name, 0)
+        if delay:
+            await asyncio.sleep(delay)
+        reply = self._replies.get(name)
+        if isinstance(reply, Exception):
+            raise reply
+        if isinstance(reply, _FakeResult):
+            return reply
+        return _FakeResult(text=str(reply) if reply is not None else "ok")
+
+
+def _spec_kwargs(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "demo",
+        "transport": "stdio",
+        "command": ["echo", "hi"],
+        "tool_prefix": "demo_",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_factory(sessions: dict[str, FakeSession]):
+    async def _factory(spec: ServerSpec, stack: AsyncExitStack) -> FakeSession:
+        session = sessions[spec.name]
+
+        async def _on_close() -> None:
+            session.closed = True
+
+        stack.push_async_callback(_on_close)
+        return session
+
+    return _factory
+
+
+def _failing_factory(error: Exception):
+    async def _factory(spec: ServerSpec, stack: AsyncExitStack) -> FakeSession:
+        raise error
+
+    return _factory
+
+
+# --------------------------------------------------------------------------- #
+# expand_env
+# --------------------------------------------------------------------------- #
+
+
+def test_expand_env_handles_strings_lists_dicts_and_tuples() -> None:
+    env = {"FOO": "x", "BAR": "y"}
+    out = expand_env(
+        {
+            "a": "${FOO}-${BAR}",
+            "b": ["${FOO}", 1, ("${BAR}",)],
+            "c": {"nested": "${FOO}${MISSING}"},
+            "d": 42,
+        },
+        env,
+    )
+    assert out == {
+        "a": "x-y",
+        "b": ["x", 1, ("y",)],
+        "c": {"nested": "x"},
+        "d": 42,
+    }
+
+
+def test_expand_env_uses_os_environ_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_TEST_VAR", "hello")
+    assert expand_env("${MCP_TEST_VAR}!") == "hello!"
+
+
+# --------------------------------------------------------------------------- #
+# ServerSpec validation
+# --------------------------------------------------------------------------- #
+
+
+def test_serverspec_rejects_stdio_without_command() -> None:
+    with pytest.raises(ValueError, match="command"):
+        ServerSpec(name="x", transport="stdio")
+
+
+def test_serverspec_rejects_stdio_with_url() -> None:
+    with pytest.raises(ValueError, match="url"):
+        ServerSpec(name="x", transport="stdio", command=["x"], url="http://x")
+
+
+def test_serverspec_rejects_http_without_url() -> None:
+    with pytest.raises(ValueError, match="url"):
+        ServerSpec(name="x", transport="http")
+
+
+def test_serverspec_rejects_http_with_command() -> None:
+    with pytest.raises(ValueError, match="command"):
+        ServerSpec(name="x", transport="http", url="http://x", command=["nope"])
+
+
+def test_serverspec_rejects_sse_without_url() -> None:
+    with pytest.raises(ValueError, match="url"):
+        ServerSpec(name="x", transport="sse")
+
+
+# --------------------------------------------------------------------------- #
+# load_config
+# --------------------------------------------------------------------------- #
+
+
+def _write(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_load_config_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(MCPClientError, match="not found"):
+        load_config(tmp_path / "missing.yaml")
+
+
+def test_load_config_invalid_yaml_raises(tmp_path: Path) -> None:
+    p = _write(tmp_path / "c.yaml", "servers: [unclosed\n")
+    with pytest.raises(MCPClientError, match="Invalid YAML"):
+        load_config(p)
+
+
+def test_load_config_top_level_must_be_mapping(tmp_path: Path) -> None:
+    p = _write(tmp_path / "c.yaml", "- 1\n- 2\n")
+    with pytest.raises(MCPClientError, match="mapping"):
+        load_config(p)
+
+
+def test_load_config_servers_must_be_list(tmp_path: Path) -> None:
+    p = _write(tmp_path / "c.yaml", "servers: 'oops'\n")
+    with pytest.raises(MCPClientError, match="list"):
+        load_config(p)
+
+
+def test_load_config_each_entry_must_be_mapping(tmp_path: Path) -> None:
+    p = _write(tmp_path / "c.yaml", "servers:\n  - 'oops'\n")
+    with pytest.raises(MCPClientError, match="mapping"):
+        load_config(p)
+
+
+def test_load_config_invalid_spec_wrapped(tmp_path: Path) -> None:
+    p = _write(tmp_path / "c.yaml", "servers:\n  - name: x\n    transport: stdio\n")
+    with pytest.raises(MCPClientError, match="invalid server spec"):
+        load_config(p)
+
+
+def test_load_config_rejects_duplicate_names(tmp_path: Path) -> None:
+    body = (
+        "servers:\n"
+        "  - name: a\n    transport: stdio\n    command: [echo]\n"
+        "  - name: a\n    transport: stdio\n    command: [echo]\n"
+    )
+    p = _write(tmp_path / "c.yaml", body)
+    with pytest.raises(MCPClientError, match="duplicate"):
+        load_config(p)
+
+
+def test_load_config_env_substitution(tmp_path: Path) -> None:
+    body = (
+        "servers:\n"
+        "  - name: a\n"
+        "    transport: stdio\n"
+        "    command: [echo, '${GREETING}']\n"
+        "    env:\n      TOKEN: ${SECRET}\n"
+    )
+    p = _write(tmp_path / "c.yaml", body)
+    specs = load_config(p, environ={"GREETING": "hi", "SECRET": "s3cr3t"})
+    assert specs[0].command == ("echo", "hi")
+    assert specs[0].env == {"TOKEN": "s3cr3t"}
+
+
+def test_load_config_empty_yaml_returns_no_servers(tmp_path: Path) -> None:
+    p = _write(tmp_path / "c.yaml", "")
+    assert load_config(p) == []
+
+
+# --------------------------------------------------------------------------- #
+# MCPManager.start / dispatch / aclose
+# --------------------------------------------------------------------------- #
+
+
+def _config_with(*entries: str) -> str:
+    return "servers:\n" + "".join(entries)
+
+
+def _entry(name: str, *, prefix: str = "", enabled: bool = True, command: str = "echo") -> str:
+    return (
+        f"  - name: {name}\n"
+        f"    enabled: {str(enabled).lower()}\n"
+        f"    transport: stdio\n"
+        f"    command: [{command}]\n"
+        f"    tool_prefix: {prefix!r}\n"
+        f"    timeout_s: 1.0\n"
+    )
+
+
+def test_start_registers_prefixed_tools_and_dispatch_works(tmp_path: Path) -> None:
+    cfg = _write(tmp_path / "c.yaml", _config_with(_entry("alpha", prefix="a_")))
+    schema = {"type": "object", "properties": {"q": {"type": "string"}}}
+    sess = FakeSession(
+        tools=[_FakeTool("search", "find things", schema)],
+        replies={"search": _FakeResult("found-it")},
+    )
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=_make_factory({"alpha": sess}))
+
+    asyncio.run(_run_dispatch(mgr, reg, sess))
+
+    statuses = mgr.list_status()
+    assert len(statuses) == 1
+    assert statuses[0].connected is True
+    assert statuses[0].tool_count == 1
+    assert statuses[0].tools == ["a_search"]
+
+
+async def _run_dispatch(mgr: MCPManager, reg: Registry, sess: FakeSession) -> None:
+    await mgr.start()
+    try:
+        tool = reg.get("a_search")
+        # Schema preserved verbatim from the remote tool.
+        assert tool.parameters_schema == {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+        }
+        assert tool.description == "find things"
+        assert tool.source == "mcp"
+        result = await tool.fn(q="hello")
+        assert result.ok is True
+        assert result.content == "found-it"
+        assert sess.calls == [("search", {"q": "hello"})]
+    finally:
+        await mgr.aclose()
+    assert sess.closed is True
+
+
+def test_disabled_servers_are_skipped(tmp_path: Path) -> None:
+    cfg = _write(
+        tmp_path / "c.yaml",
+        _config_with(_entry("on_srv", prefix="o_"), _entry("off_srv", enabled=False)),
+    )
+    sess_on = FakeSession(tools=[_FakeTool("ping")])
+    factory = _make_factory({"on_srv": sess_on})
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=factory)
+
+    async def go() -> None:
+        await mgr.start()
+        statuses = {s.name: s for s in mgr.list_status()}
+        assert statuses["off_srv"].connected is False
+        assert statuses["off_srv"].error == "disabled"
+        assert statuses["on_srv"].connected is True
+        assert "o_ping" in reg
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_failing_server_isolated_from_others(tmp_path: Path) -> None:
+    cfg = _write(
+        tmp_path / "c.yaml",
+        _config_with(_entry("good", prefix="g_"), _entry("bad", prefix="b_")),
+    )
+    good = FakeSession(tools=[_FakeTool("ok")])
+    bad = FakeSession(list_error=RuntimeError("nope"))
+
+    async def factory(spec: ServerSpec, stack: AsyncExitStack) -> FakeSession:
+        sess = good if spec.name == "good" else bad
+
+        async def _on_close() -> None:
+            sess.closed = True
+
+        stack.push_async_callback(_on_close)
+        if spec.name == "bad":
+            # Simulate connect-time failure by raising during list_tools.
+            return bad
+        return good
+
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=factory)
+
+    async def go() -> None:
+        await mgr.start()
+        statuses = {s.name: s for s in mgr.list_status()}
+        assert statuses["good"].connected is True
+        assert statuses["bad"].connected is False
+        assert "nope" in (statuses["bad"].error or "")
+        assert "g_ok" in reg
+        assert not any(name.startswith("b_") for name in reg.names())
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_unreachable_server_at_factory_time(tmp_path: Path) -> None:
+    cfg = _write(tmp_path / "c.yaml", _config_with(_entry("dead")))
+    reg = Registry()
+    mgr = MCPManager(
+        cfg,
+        registry=reg,
+        session_factory=_failing_factory(ConnectionError("boom")),
+    )
+
+    async def go() -> None:
+        await mgr.start()
+        statuses = mgr.list_status()
+        assert statuses[0].connected is False
+        assert "boom" in (statuses[0].error or "")
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_dispatch_call_error_returns_tool_result(tmp_path: Path) -> None:
+    cfg = _write(tmp_path / "c.yaml", _config_with(_entry("s", prefix="s_")))
+    sess = FakeSession(
+        tools=[_FakeTool("act")],
+        replies={"act": RuntimeError("explode")},
+    )
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=_make_factory({"s": sess}))
+
+    async def go() -> None:
+        await mgr.start()
+        result = await reg.get("s_act").fn()
+        assert result.ok is False
+        assert "explode" in (result.error or "")
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_dispatch_tool_reports_error(tmp_path: Path) -> None:
+    cfg = _write(tmp_path / "c.yaml", _config_with(_entry("s", prefix="s_")))
+    sess = FakeSession(
+        tools=[_FakeTool("act")],
+        replies={"act": _FakeResult("bad-input", is_error=True)},
+    )
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=_make_factory({"s": sess}))
+
+    async def go() -> None:
+        await mgr.start()
+        result = await reg.get("s_act").fn()
+        assert result.ok is False
+        assert result.error == "bad-input"
+        # Empty error text falls back to a default message.
+        sess._replies["act"] = _FakeResult("", is_error=True)
+        result = await reg.get("s_act").fn()
+        assert result.ok is False
+        assert "tool reported error" in (result.error or "")
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_dispatch_timeout_returns_error(tmp_path: Path) -> None:
+    body = (
+        "servers:\n"
+        "  - name: slow\n    enabled: true\n    transport: stdio\n"
+        "    command: [echo]\n    tool_prefix: 's_'\n    timeout_s: 0.05\n"
+    )
+    cfg = _write(tmp_path / "c.yaml", body)
+    sess = FakeSession(tools=[_FakeTool("nap")], call_delays={"nap": 1.0})
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=_make_factory({"slow": sess}))
+
+    async def go() -> None:
+        await mgr.start()
+        result = await reg.get("s_nap").fn()
+        assert result.ok is False
+        assert "timeout" in (result.error or "")
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_prefix_collisions_keep_each_server_namespaced(tmp_path: Path) -> None:
+    cfg = _write(
+        tmp_path / "c.yaml",
+        _config_with(_entry("a", prefix="a_"), _entry("b", prefix="b_")),
+    )
+    sa = FakeSession(tools=[_FakeTool("dup")], replies={"dup": _FakeResult("from-a")})
+    sb = FakeSession(tools=[_FakeTool("dup")], replies={"dup": _FakeResult("from-b")})
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=_make_factory({"a": sa, "b": sb}))
+
+    async def go() -> None:
+        await mgr.start()
+        assert reg.names() == ["a_dup", "b_dup"]
+        ra = await reg.get("a_dup").fn()
+        rb = await reg.get("b_dup").fn()
+        assert ra.content == "from-a"
+        assert rb.content == "from-b"
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_reload_adds_removes_and_keeps_unchanged(tmp_path: Path) -> None:
+    cfg = _write(
+        tmp_path / "c.yaml",
+        _config_with(_entry("keep", prefix="k_"), _entry("drop", prefix="d_")),
+    )
+    keep = FakeSession(tools=[_FakeTool("t")])
+    drop = FakeSession(tools=[_FakeTool("t")])
+    add = FakeSession(tools=[_FakeTool("t")])
+    sessions = {"keep": keep, "drop": drop, "add": add}
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=_make_factory(sessions))
+
+    async def go() -> None:
+        await mgr.start()
+        assert {"k_t", "d_t"} <= set(reg.names())
+
+        # Rewrite the config: drop "drop", add "add".
+        cfg.write_text(
+            _config_with(_entry("keep", prefix="k_"), _entry("add", prefix="a_")),
+            encoding="utf-8",
+        )
+        await mgr.reload()
+        assert set(reg.names()) == {"k_t", "a_t"}
+        assert drop.closed is True
+        # The 'keep' session was reused, not closed and re-opened.
+        assert keep.closed is False
+        names = {s.name for s in mgr.list_status()}
+        assert names == {"keep", "add"}
+        await mgr.aclose()
+        assert keep.closed is True
+        assert add.closed is True
+
+    asyncio.run(go())
+
+
+def test_reload_reopens_when_spec_changes(tmp_path: Path) -> None:
+    cfg = _write(tmp_path / "c.yaml", _config_with(_entry("s", prefix="s_")))
+    s1 = FakeSession(tools=[_FakeTool("v1")])
+    s2 = FakeSession(tools=[_FakeTool("v2")])
+    seq = iter([s1, s2])
+
+    async def factory(spec: ServerSpec, stack: AsyncExitStack) -> FakeSession:
+        sess = next(seq)
+
+        async def _on_close() -> None:
+            sess.closed = True
+
+        stack.push_async_callback(_on_close)
+        return sess
+
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=factory)
+
+    async def go() -> None:
+        await mgr.start()
+        assert "s_v1" in reg
+        # Change the timeout_s -> spec inequality -> reconnect.
+        body = (
+            "servers:\n"
+            "  - name: s\n    enabled: true\n    transport: stdio\n"
+            "    command: [echo]\n    tool_prefix: 's_'\n    timeout_s: 5.0\n"
+        )
+        cfg.write_text(body, encoding="utf-8")
+        await mgr.reload()
+        assert "s_v2" in reg
+        assert "s_v1" not in reg
+        assert s1.closed is True
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_disconnect_swallows_close_errors(tmp_path: Path) -> None:
+    cfg = _write(tmp_path / "c.yaml", _config_with(_entry("x", prefix="x_")))
+    sess = FakeSession(tools=[_FakeTool("t")])
+
+    async def factory(spec: ServerSpec, stack: AsyncExitStack) -> FakeSession:
+        async def _on_close() -> None:
+            raise RuntimeError("close-fail")
+
+        stack.push_async_callback(_on_close)
+        return sess
+
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=factory)
+
+    async def go() -> None:
+        await mgr.start()
+        # Should NOT raise even though the close callback errors.
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_tool_listing_supports_dict_entries(tmp_path: Path) -> None:
+    """The fake's content extractor handles dict-shaped tools and content."""
+    from orchestrator.tools.mcp_client import _content_to_text
+
+    assert _content_to_text(None) == ""
+    assert _content_to_text("plain") == "plain"
+    assert _content_to_text([{"text": "a"}, {"other": 1}]) == "a\n{'other': 1}"
+    assert _content_to_text(123) == "123"
+
+    # Manager should also accept dict-shaped remote tools.
+    cfg = _write(tmp_path / "c.yaml", _config_with(_entry("d", prefix="d_")))
+
+    class DictSession(FakeSession):
+        async def list_tools(self) -> Any:
+            return _FakeListToolsResp(
+                [
+                    {  # type: ignore[list-item]
+                        "name": "raw",
+                        "description": "dict-shaped",
+                        "inputSchema": {"type": "object"},
+                    }
+                ]
+            )
+
+    sess = DictSession(replies={"raw": _FakeResult("ok")})
+    reg = Registry()
+    mgr = MCPManager(cfg, registry=reg, session_factory=_make_factory({"d": sess}))
+
+    async def go() -> None:
+        await mgr.start()
+        tool = reg.get("d_raw")
+        assert tool.description == "dict-shaped"
+        assert tool.parameters_schema == {"type": "object"}
+        await mgr.aclose()
+
+    asyncio.run(go())
+
+
+def test_default_registry_is_used_when_unspecified(tmp_path: Path) -> None:
+    from orchestrator.tools.registry import default_registry
+
+    default_registry.clear()
+    cfg = _write(tmp_path / "c.yaml", _config_with(_entry("z", prefix="z_")))
+    sess = FakeSession(tools=[_FakeTool("ping")])
+    mgr = MCPManager(cfg, session_factory=_make_factory({"z": sess}))
+
+    async def go() -> None:
+        await mgr.start()
+        assert "z_ping" in default_registry
+        await mgr.aclose()
+        assert "z_ping" not in default_registry
+
+    asyncio.run(go())
+
+
+def test_config_path_property(tmp_path: Path) -> None:
+    cfg = _write(tmp_path / "c.yaml", _config_with(_entry("a")))
+    mgr = MCPManager(cfg)
+    assert mgr.config_path == cfg

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,0 +1,60 @@
+"""Tests for the minimal in-process tool registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.tools.registry import Registry, Tool, ToolResult, default_registry
+
+
+def _tool(name: str, source: str = "builtin") -> Tool:
+    return Tool(name=name, description="", parameters_schema={}, source=source)
+
+
+def test_register_and_get_roundtrip() -> None:
+    reg = Registry()
+    t = _tool("a")
+    reg.register(t)
+    assert "a" in reg
+    assert reg.get("a") is t
+    assert reg.names() == ["a"]
+    assert len(reg) == 1
+
+
+def test_register_duplicate_raises_unless_replace() -> None:
+    reg = Registry()
+    reg.register(_tool("a"))
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(_tool("a"))
+    new = _tool("a")
+    reg.register(new, replace=True)
+    assert reg.get("a") is new
+
+
+def test_unregister_is_idempotent() -> None:
+    reg = Registry()
+    reg.register(_tool("a"))
+    reg.unregister("a")
+    reg.unregister("a")
+    assert "a" not in reg
+
+
+def test_by_source_and_clear() -> None:
+    reg = Registry()
+    reg.register(_tool("a", source="builtin"))
+    reg.register(_tool("b", source="mcp"))
+    reg.register(_tool("c", source="mcp"))
+    assert sorted(t.name for t in reg.by_source("mcp")) == ["b", "c"]
+    reg.clear()
+    assert len(reg) == 0
+
+
+def test_tool_result_envelope_defaults() -> None:
+    ok = ToolResult(ok=True, content={"x": 1})
+    assert ok.error is None
+    err = ToolResult(ok=False, error="bad")
+    assert err.content is None
+
+
+def test_default_registry_is_module_level_singleton() -> None:
+    assert isinstance(default_registry, Registry)


### PR DESCRIPTION
Closes #45

## Summary

Adds a config-driven MCP client that lets the orchestrator consume any number of remote or cloud-hosted MCP servers (GitHub, Atlassian, Context7, custom internal servers, ...) and surface their tools through a central in-process tool registry, so the coder model can call them like any local tool.

## Acceptance Criteria met

- [x] `config/mcp_servers.yaml.example` documents the YAML schema (stdio | http | sse, env, headers, timeout_s, tool_prefix).
- [x] `orchestrator/tools/mcp_client.py` reads the config at startup, env-substitutes `` from `os.environ`, and connects to each `enabled: true` server via the official `mcp` SDK (default factory) or an injected factory (tests).
- [x] For each server: `list_tools` is called, every remote tool is wrapped as a local `Tool` named `{tool_prefix}{remote_name}` with the JSON schema preserved verbatim, and registered against `default_registry`. Dispatch translates `(args)` into an MCP `call_tool` round-trip and returns the standard `ToolResult` envelope.
- [x] Per-server failures are isolated (one unreachable server logs a warning and is skipped, others still load) and a failed `call_tool` returns `ToolResult(ok=False, error=...)` and never raises.
- [x] Each MCP call respects `timeout_s` via `asyncio.wait_for`.
- [x] CLI: `orchestrator mcp list` prints connected servers + tool count + status; `orchestrator mcp reload` re-reads the config (closes removed sessions, opens new ones, leaves unchanged ones alive).
- [x] All MCP traffic logged at `INFO` (server, tool, duration, ok/err); arguments only at `DEBUG`, never at `INFO`.
- [x] Tests in `tests/tools/test_mcp_client.py` use an in-process `FakeSession` injected via `session_factory` to verify registration, dispatch happy path, schema preservation, prefix collision avoidance, server-down isolation, timeout, env-var substitution, and reload behaviour. No subprocesses, no network.

## Files

- `orchestrator/tools/mcp_client.py`
- `orchestrator/tools/registry.py` (minimal stand-in for #30 so the public surface `register` / `unregister` / `get` / `names` stays stable)
- `orchestrator/cli.py`
- `orchestrator/tools/__init__.py`
- `config/mcp_servers.yaml.example` (and `config/mcp_servers.yaml` gitignored)
- `tests/tools/test_mcp_client.py`, `tests/tools/test_registry.py`, `tests/test_cli.py`
- `pyproject.toml` (adds `mcp>=1.0,<2`, `pyyaml>=6.0`, `orchestrator` console-script)
- `docs/PLAN.md`, `README.md`

## Verification

- `ruff check .` — clean
- `ruff format --check .` — clean
- `pytest --cov=orchestrator --cov-fail-under=95` — 165 passed, total coverage 99.06%
