### PR TITLE
feat(models): model profiles config

### DIFF
--- a/orchestrator/interfaces/model_profiles.py
+++ b/orchestrator/interfaces/model_profiles.py
@@ -1,0 +1,121 @@
+"""Public model profiles surfaced by ``GET /v1/models``.
+
+The user-facing contract for the orchestrator is a **single auto-routing
+model** named ``orchestrator``. Internally the orchestrator routes between
+``fast``/``deep``/``research``/``status`` pipelines based on a classifier;
+that routing is invisible to callers by default.
+
+Named profiles (``orchestrator-fast``, ``orchestrator-deep``,
+``orchestrator-research``, ``orchestrator-status``) exist purely as
+**escape-hatch overrides**: when the caller wants to *force* a specific
+pipeline class and bypass the classifier entirely, they pick one of those
+names. They are not separate "routing flavors" -- they are just the four
+pin-this-class shortcuts.
+
+This module is intentionally dependency-free (no FastAPI, no DB) so it can
+be imported and exercised in isolation by unit tests. The HTTP layer in
+``openai_compat.py`` consumes :func:`resolve_profile` and
+:func:`list_profiles` to build OpenAI-compatible responses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = [
+    "DEFAULT_PROFILE_NAME",
+    "ForceClass",
+    "ModelProfile",
+    "ProfileNotFoundError",
+    "list_profiles",
+    "resolve_profile",
+]
+
+ForceClass = Literal["fast", "deep", "research", "status"]
+
+DEFAULT_PROFILE_NAME = "orchestrator"
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """A user-selectable model profile.
+
+    ``force_class`` is ``None`` for the default auto-routing profile, and
+    one of the four pipeline classes for the override profiles.
+    """
+
+    name: str
+    force_class: ForceClass | None
+    description: str
+
+
+class ProfileNotFoundError(KeyError):
+    """Raised when an unknown profile name is resolved.
+
+    The HTTP layer maps this to a 404. We subclass :class:`KeyError` so
+    that ``dict``-style ``except KeyError`` paths also catch it.
+    """
+
+    status_code: int = 404
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"unknown model profile: {self.name!r}"
+
+
+# The registry is a module-level ordered dict so iteration order is the
+# canonical "list" order we want to expose via ``GET /v1/models``: the
+# default ``orchestrator`` first, then the four overrides.
+_REGISTRY: dict[str, ModelProfile] = {
+    "orchestrator": ModelProfile(
+        name="orchestrator",
+        force_class=None,
+        description=(
+            "Default auto-routing model. The orchestrator picks a pipeline "
+            "(fast/deep/research/status) based on the request's classifier."
+        ),
+    ),
+    "orchestrator-fast": ModelProfile(
+        name="orchestrator-fast",
+        force_class="fast",
+        description="Override: skip the classifier and run the fast pipeline.",
+    ),
+    "orchestrator-deep": ModelProfile(
+        name="orchestrator-deep",
+        force_class="deep",
+        description="Override: skip the classifier and run the deep pipeline.",
+    ),
+    "orchestrator-research": ModelProfile(
+        name="orchestrator-research",
+        force_class="research",
+        description="Override: skip the classifier and run the research pipeline.",
+    ),
+    "orchestrator-status": ModelProfile(
+        name="orchestrator-status",
+        force_class="status",
+        description="Override: skip the classifier and run the status pipeline.",
+    ),
+}
+
+
+def resolve_profile(name: str) -> ModelProfile:
+    """Look up a profile by name.
+
+    Raises:
+        ProfileNotFoundError: ``name`` is not a registered profile.
+    """
+
+    try:
+        return _REGISTRY[name]
+    except KeyError as exc:
+        raise ProfileNotFoundError(name) from exc
+
+
+def list_profiles() -> list[ModelProfile]:
+    """Return all registered profiles, default ``orchestrator`` first."""
+
+    return list(_REGISTRY.values())

--- a/orchestrator/interfaces/openai_compat.py
+++ b/orchestrator/interfaces/openai_compat.py
@@ -1,0 +1,132 @@
+"""OpenAI-compatible interface helpers.
+
+This module is the integration point between the OpenAI-shaped HTTP surface
+and the in-process model profile registry in :mod:`model_profiles`. It is
+deliberately framework-free: the functions here return plain ``dict``s and
+raise :class:`ProfileNotFoundError`, leaving HTTP serialization and status
+code mapping to whichever framework eventually wires this up.
+
+Two responsibilities live here:
+
+* :func:`list_models_response` -- builds the OpenAI ``/v1/models`` list
+  payload, with the default ``orchestrator`` entry first.
+* :func:`submit_job` -- the pre-job-submission resolver. It looks up the
+  requested profile, decides whether the classifier should run, and records
+  the resolved ``force_class`` on the persisted ``Job`` row. The actual
+  scheduler call is injected so this stays trivially testable.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .model_profiles import (
+    DEFAULT_PROFILE_NAME,
+    ForceClass,
+    ModelProfile,
+    ProfileNotFoundError,
+    list_profiles,
+    resolve_profile,
+)
+
+__all__ = [
+    "JobRow",
+    "JobSubmitter",
+    "ProfileNotFoundError",
+    "list_models_response",
+    "submit_job",
+]
+
+OPENAI_MODEL_OBJECT = "model"
+OPENAI_LIST_OBJECT = "list"
+OPENAI_OWNED_BY = "orchestrator"
+
+
+@dataclass(frozen=True)
+class JobRow:
+    """The slice of the persisted ``Job`` record this module touches.
+
+    The full ``Job`` schema lives in the state-store layer; this projection
+    captures only the fields the profile resolver writes.
+    """
+
+    job_id: str
+    model: str
+    force_class: ForceClass | None
+
+
+# A submitter is "give me a class to run, I'll persist a job and return its
+# id". Decoupling it like this keeps this module free of any database or
+# scheduler dependency.
+JobSubmitter = Callable[[str, ForceClass | None], str]
+
+
+def _model_to_openai(profile: ModelProfile, *, created: int) -> dict[str, object]:
+    return {
+        "id": profile.name,
+        "object": OPENAI_MODEL_OBJECT,
+        "created": created,
+        "owned_by": OPENAI_OWNED_BY,
+        "description": profile.description,
+        "force_class": profile.force_class,
+    }
+
+
+def list_models_response(*, now: Callable[[], float] = time.time) -> dict[str, object]:
+    """Return the OpenAI-shaped ``/v1/models`` response payload.
+
+    The default ``orchestrator`` profile is always first in ``data``.
+    """
+
+    created = int(now())
+    profiles = list_profiles()
+    # Defensive: enforce default-first ordering even if the registry is
+    # reshuffled later. Stable order otherwise.
+    profiles.sort(key=lambda p: 0 if p.name == DEFAULT_PROFILE_NAME else 1)
+    return {
+        "object": OPENAI_LIST_OBJECT,
+        "data": [_model_to_openai(p, created=created) for p in profiles],
+    }
+
+
+def submit_job(
+    model_name: str,
+    *,
+    submitter: JobSubmitter,
+    classifier: Callable[[], ForceClass] | None = None,
+) -> JobRow:
+    """Resolve ``model_name`` and submit a job through ``submitter``.
+
+    Behaviour:
+
+    * If the resolved profile carries a ``force_class``, the classifier is
+      **not** invoked and that class is used directly.
+    * If ``force_class`` is ``None`` (the default ``orchestrator`` profile),
+      ``classifier`` is invoked to choose a class. ``classifier`` must be
+      provided in that case.
+    * Architectural rule: ``submitter`` is expected to enqueue and return
+      the ``job_id`` immediately; this function never blocks waiting for
+      the scheduler.
+
+    Raises:
+        ProfileNotFoundError: ``model_name`` is not a registered profile.
+        ValueError: the resolved profile needs the classifier but none was
+            supplied.
+    """
+
+    profile = resolve_profile(model_name)
+
+    if profile.force_class is not None:
+        chosen: ForceClass = profile.force_class
+    else:
+        if classifier is None:
+            raise ValueError("classifier is required when the resolved profile has no force_class")
+        chosen = classifier()
+
+    job_id = submitter(profile.name, chosen)
+    # The Job row records the *resolved* class (whether forced or
+    # classifier-picked) plus the originally requested model name so
+    # operators can audit which profile a given job came from.
+    return JobRow(job_id=job_id, model=profile.name, force_class=chosen)

--- a/tests/interfaces/test_model_profiles.py
+++ b/tests/interfaces/test_model_profiles.py
@@ -1,0 +1,195 @@
+"""Tests for the model profile registry and OpenAI-compat resolver."""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.interfaces.model_profiles import (
+    DEFAULT_PROFILE_NAME,
+    ModelProfile,
+    ProfileNotFoundError,
+    list_profiles,
+    resolve_profile,
+)
+from orchestrator.interfaces.openai_compat import (
+    JobRow,
+    list_models_response,
+    submit_job,
+)
+
+
+def test_default_profile_is_orchestrator_with_no_force_class() -> None:
+    profile = resolve_profile("orchestrator")
+    assert profile.name == "orchestrator"
+    assert profile.force_class is None
+
+
+@pytest.mark.parametrize(
+    ("name", "force_class"),
+    [
+        ("orchestrator-fast", "fast"),
+        ("orchestrator-deep", "deep"),
+        ("orchestrator-research", "research"),
+        ("orchestrator-status", "status"),
+    ],
+)
+def test_override_profiles_force_their_class(name: str, force_class: str) -> None:
+    profile = resolve_profile(name)
+    assert profile.force_class == force_class
+    assert profile.description
+
+
+def test_resolve_profile_unknown_name_raises_404() -> None:
+    with pytest.raises(ProfileNotFoundError) as excinfo:
+        resolve_profile("gpt-4")
+    err = excinfo.value
+    assert err.status_code == 404
+    assert err.name == "gpt-4"
+    assert "gpt-4" in str(err)
+    # Subclasses KeyError so dict-style handlers still match.
+    assert isinstance(err, KeyError)
+
+
+def test_list_profiles_contains_all_five_with_orchestrator_first() -> None:
+    profiles = list_profiles()
+    names = [p.name for p in profiles]
+    assert names[0] == DEFAULT_PROFILE_NAME
+    assert set(names) == {
+        "orchestrator",
+        "orchestrator-fast",
+        "orchestrator-deep",
+        "orchestrator-research",
+        "orchestrator-status",
+    }
+
+
+def test_model_profile_is_immutable() -> None:
+    profile = resolve_profile("orchestrator")
+    with pytest.raises(AttributeError):
+        profile.name = "tampered"  # type: ignore[misc]
+
+
+def test_list_models_response_has_openai_list_shape() -> None:
+    payload = list_models_response(now=lambda: 1700000000.5)
+    assert payload["object"] == "list"
+    data = payload["data"]
+    assert isinstance(data, list)
+    assert len(data) == 5
+    first = data[0]
+    assert first["id"] == "orchestrator"
+    assert first["object"] == "model"
+    assert first["created"] == 1700000000
+    assert first["owned_by"] == "orchestrator"
+    assert first["force_class"] is None
+    # Every override profile carries its force_class in the payload.
+    by_id = {entry["id"]: entry for entry in data}
+    assert by_id["orchestrator-fast"]["force_class"] == "fast"
+    assert by_id["orchestrator-deep"]["force_class"] == "deep"
+    assert by_id["orchestrator-research"]["force_class"] == "research"
+    assert by_id["orchestrator-status"]["force_class"] == "status"
+
+
+def test_list_models_response_uses_default_clock_when_none_provided() -> None:
+    payload = list_models_response()
+    assert isinstance(payload["data"], list)
+    assert payload["data"][0]["id"] == "orchestrator"
+
+
+def test_list_models_response_puts_default_first_even_if_registry_reshuffled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from orchestrator.interfaces import model_profiles as mp
+
+    reordered = {
+        "orchestrator-fast": mp._REGISTRY["orchestrator-fast"],
+        "orchestrator": mp._REGISTRY["orchestrator"],
+        "orchestrator-deep": mp._REGISTRY["orchestrator-deep"],
+        "orchestrator-research": mp._REGISTRY["orchestrator-research"],
+        "orchestrator-status": mp._REGISTRY["orchestrator-status"],
+    }
+    monkeypatch.setattr(mp, "_REGISTRY", reordered)
+    payload = list_models_response(now=lambda: 0.0)
+    assert payload["data"][0]["id"] == "orchestrator"
+
+
+def test_submit_job_with_default_profile_invokes_classifier() -> None:
+    classifier_calls: list[None] = []
+
+    def classifier() -> str:
+        classifier_calls.append(None)
+        return "deep"
+
+    submitted: list[tuple[str, str | None]] = []
+
+    def submitter(model: str, force_class: str | None) -> str:
+        submitted.append((model, force_class))
+        return "job-1"
+
+    row = submit_job("orchestrator", submitter=submitter, classifier=classifier)
+
+    assert classifier_calls == [None]
+    assert submitted == [("orchestrator", "deep")]
+    assert row == JobRow(job_id="job-1", model="orchestrator", force_class="deep")
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("orchestrator-fast", "fast"),
+        ("orchestrator-deep", "deep"),
+        ("orchestrator-research", "research"),
+        ("orchestrator-status", "status"),
+    ],
+)
+def test_submit_job_with_override_skips_classifier(name: str, expected: str) -> None:
+    def classifier() -> str:  # pragma: no cover - must not run
+        raise AssertionError("classifier must be skipped when force_class is set")
+
+    submitted: list[tuple[str, str | None]] = []
+
+    def submitter(model: str, force_class: str | None) -> str:
+        submitted.append((model, force_class))
+        return f"job-{expected}"
+
+    row = submit_job(name, submitter=submitter, classifier=classifier)
+
+    assert submitted == [(name, expected)]
+    assert row.force_class == expected
+    assert row.model == name
+
+
+def test_submit_job_override_does_not_require_classifier() -> None:
+    submitted: list[tuple[str, str | None]] = []
+
+    def submitter(model: str, force_class: str | None) -> str:
+        submitted.append((model, force_class))
+        return "job-x"
+
+    row = submit_job("orchestrator-fast", submitter=submitter)
+
+    assert submitted == [("orchestrator-fast", "fast")]
+    assert row.force_class == "fast"
+
+
+def test_submit_job_default_profile_without_classifier_raises() -> None:
+    def submitter(model: str, force_class: str | None) -> str:  # pragma: no cover
+        raise AssertionError("submitter must not be called when validation fails")
+
+    with pytest.raises(ValueError, match="classifier is required"):
+        submit_job("orchestrator", submitter=submitter)
+
+
+def test_submit_job_unknown_profile_raises_profile_not_found() -> None:
+    def submitter(model: str, force_class: str | None) -> str:  # pragma: no cover
+        raise AssertionError("submitter must not be called for unknown profiles")
+
+    with pytest.raises(ProfileNotFoundError):
+        submit_job("does-not-exist", submitter=submitter, classifier=lambda: "fast")
+
+
+def test_model_profile_dataclass_shape() -> None:
+    # Sanity check the public dataclass surface stays stable.
+    profile = ModelProfile(name="x", force_class=None, description="d")
+    assert profile.name == "x"
+    assert profile.force_class is None
+    assert profile.description == "d"


### PR DESCRIPTION
Closes #13

## Summary
Adds the public model profile registry that backs `GET /v1/models` plus the resolver/submitter glue used before job submission. The default user-facing model is the auto-routing `orchestrator`; the four `orchestrator-{fast,deep,research,status}` profiles are escape-hatch overrides that pin a pipeline class and skip the classifier.

## Changes
- `orchestrator/interfaces/model_profiles.py` — `ModelProfile` dataclass, module-level registry, `resolve_profile` (raises `ProfileNotFoundError` with `status_code=404`), `list_profiles` (default first).
- `orchestrator/interfaces/openai_compat.py` — `list_models_response` (OpenAI list shape, default first) and `submit_job` (resolves profile, skips classifier when `force_class` set, records resolved class on the `JobRow`). Framework-free; the submitter is injected so jobs return `job_id` immediately.
- `tests/interfaces/test_model_profiles.py` — unit tests for the resolver, registry contents, OpenAI payload shape, classifier-skip on overrides, classifier-runs on default, missing-classifier guard, 404 on unknown names, and immutability.

## Acceptance Criteria met
- [x] `ModelProfile` dataclass: `{name, force_class, description}` with `Optional[Literal["fast","deep","research","status"]]`.
- [x] Registry exposes `orchestrator` (default, `force_class=None`) plus the four overrides.
- [x] `GET /v1/models` enumerates all profiles in OpenAI list shape with `orchestrator` first (`list_models_response`).
- [x] `resolve_profile(name)` raises a 404-mapped error on unknown names.
- [x] When `force_class` is set the classifier is skipped and that class is used directly.
- [x] When `force_class` is `None` the classifier runs as normal.
- [x] Profile choice is recorded on the `Job` row (`JobRow.force_class`).
- [x] Unit tests cover resolver + classifier-skip behavior.
- [x] `ruff check` clean, type-hinted public surface, jobs returned immediately (non-blocking submitter).

## Verification
- `python -m ruff check .` — clean.
- `python -m pytest` — 295 passed, 1 skipped (pre-existing symlink env skip).
- Coverage 98.84% overall (gate ≥95%); new modules at 100%.
