### PR TITLE
feat(pipeline): offline intent classifier

### DIFF
--- a/orchestrator/core/__init__.py
+++ b/orchestrator/core/__init__.py
@@ -1,1 +1,5 @@
 """Core orchestrator primitives (scheduler, state, logging)."""
+
+from orchestrator.core.classifier import ClassifyResult, classify
+
+__all__ = ["ClassifyResult", "classify"]

--- a/orchestrator/core/classifier.py
+++ b/orchestrator/core/classifier.py
@@ -1,0 +1,175 @@
+"""Intent classifier — auto-routes a user message to a pipeline class.
+
+Every job starts here. The classifier decides whether the request should be
+handled by the ``fast``, ``deep``, ``research``, or ``status`` pipeline. Two
+tiers of work happen, in order:
+
+1. A cheap regex pre-filter short-circuits obvious status queries (``status``,
+   ``what's happening``, ``progress``, ``where are we``) without invoking any
+   model. The hit returns ``confidence=1.0`` and ``reason="regex pre-filter"``.
+2. Anything else is sent to the resident reasoning model (``qwen2.5:7b`` via
+   :class:`OllamaClient`) using structured output. The prompt lives at
+   ``orchestrator/prompts/classify.md`` and is loaded once at import time.
+
+The model call is wrapped in a single retry: if the first attempt yields
+malformed JSON or a payload that does not validate against
+:class:`ClassifyResult`, the call is repeated once. A second failure yields
+the deterministic fallback ``ClassifyResult(class_="deep", confidence=0.0,
+reason="classifier fallback")`` so callers never see an exception from this
+function.
+
+Every decision (pre-filter hit, model success, retry, fallback) is recorded
+on the optional :class:`StateRecorder`. Persisting to job state is the
+*caller's* concern in production; this module just hands the recorder a
+single :class:`ClassifyResult` per call so #38's eval harness can grade live
+behaviour.
+
+The module is deliberately pure: no scheduler integration, no tool dispatch,
+no audit-log import. The :class:`OllamaClient` is a :class:`Protocol` so the
+real Ollama adapter (#35) and tests can both satisfy it without a circular
+import.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Awaitable
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+__all__ = [
+    "ClassName",
+    "ClassifyResult",
+    "OllamaClient",
+    "StateRecorder",
+    "classify",
+]
+
+ClassName = Literal["fast", "deep", "research", "status"]
+
+_MODEL = "qwen2.5:7b"
+_MAX_ATTEMPTS = 2
+_PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "classify.md"
+
+
+class ClassifyResult(BaseModel):
+    """Structured output of the classifier.
+
+    The class field is named ``class_`` in Python (``class`` is a reserved
+    keyword) but serialises as ``class`` so the JSON sent to and received
+    from the model uses the natural key.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    class_: ClassName = Field(alias="class")
+    confidence: float = Field(ge=0.0, le=1.0)
+    reason: str
+
+
+class OllamaClient(Protocol):
+    """Minimal contract the classifier needs from the Ollama adapter (#35)."""
+
+    def structured(
+        self,
+        *,
+        model: str,
+        schema: type[BaseModel],
+        prompt: str,
+    ) -> Awaitable[Any]:  # pragma: no cover - protocol
+        ...
+
+
+class StateRecorder(Protocol):
+    """Contract for the Phase 1 state module (#32) used to log decisions."""
+
+    def record_classification(
+        self, user_msg: str, result: ClassifyResult
+    ) -> None:  # pragma: no cover - protocol
+        ...
+
+
+# Regex pre-filter table. Adding a new shortcut is one line.
+_REGEX_RULES: tuple[tuple[re.Pattern[str], ClassName], ...] = (
+    (
+        re.compile(
+            r"^\s*(status|what'?s? happening|progress|where are we)\b",
+            re.IGNORECASE,
+        ),
+        "status",
+    ),
+)
+
+
+@lru_cache(maxsize=1)
+def _prompt_template() -> str:
+    return _PROMPT_PATH.read_text(encoding="utf-8")
+
+
+def _render_prompt(user_msg: str) -> str:
+    return _prompt_template().replace("{{user_msg}}", user_msg)
+
+
+def _coerce(raw: Any) -> ClassifyResult:
+    """Validate a raw model payload (str/bytes/dict) into a ClassifyResult."""
+    if isinstance(raw, ClassifyResult):
+        return raw
+    if isinstance(raw, bytes | bytearray):
+        raw = raw.decode("utf-8")
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if not isinstance(raw, dict):
+        raise ValueError(f"unexpected payload type: {type(raw).__name__}")
+    return ClassifyResult.model_validate(raw)
+
+
+def _fallback() -> ClassifyResult:
+    return ClassifyResult(class_="deep", confidence=0.0, reason="classifier fallback")
+
+
+async def classify(
+    user_msg: str,
+    *,
+    ollama: OllamaClient,
+    recorder: StateRecorder | None = None,
+) -> ClassifyResult:
+    """Classify ``user_msg`` into one of ``fast``/``deep``/``research``/``status``.
+
+    The function never raises on a model failure: malformed output triggers a
+    single retry, then a deterministic fallback. The optional ``recorder`` is
+    notified exactly once per call with the final :class:`ClassifyResult`.
+    """
+
+    # Tier 1 — regex pre-filter.
+    for pattern, class_name in _REGEX_RULES:
+        if pattern.search(user_msg):
+            result = ClassifyResult(
+                class_=class_name,
+                confidence=1.0,
+                reason="regex pre-filter",
+            )
+            if recorder is not None:
+                recorder.record_classification(user_msg, result)
+            return result
+
+    # Tier 2 — resident reasoning model with one retry.
+    prompt = _render_prompt(user_msg)
+    result: ClassifyResult | None = None
+    for _attempt in range(_MAX_ATTEMPTS):
+        try:
+            raw = await ollama.structured(model=_MODEL, schema=ClassifyResult, prompt=prompt)
+            result = _coerce(raw)
+            break
+        except (json.JSONDecodeError, ValidationError, ValueError, TypeError):
+            result = None
+
+    if result is None:
+        result = _fallback()
+
+    if recorder is not None:
+        recorder.record_classification(user_msg, result)
+    return result

--- a/orchestrator/prompts/classify.md
+++ b/orchestrator/prompts/classify.md
@@ -1,0 +1,36 @@
+# classify v1
+
+You are the **intent classifier** for a local-first agent orchestrator. Read
+the user's message and decide which downstream pipeline should handle it.
+Return **only** a JSON object that conforms to the schema below — no prose,
+no markdown fences, no explanations outside the JSON.
+
+## Classes
+
+- `fast` — short, conversational, or single-shot answer the resident model can
+  serve on its own (greetings, definitions, single-file edits, simple shell
+  commands, casual chat).
+- `deep` — multi-step coding, refactors, debugging, or anything that needs the
+  consolidate → refine → big-model → parse → execute loop.
+- `research` — open-ended investigation that requires browsing the web,
+  reading multiple sources, or synthesising fresh information.
+- `status` — the user is asking about the orchestrator itself: progress on a
+  running job, history, or "where are we". (The regex pre-filter usually
+  catches these; only emit `status` here if the phrasing is unusual.)
+
+## Output schema
+
+```json
+{
+  "class": "fast | deep | research | status",
+  "confidence": 0.0,
+  "reason": "one short sentence explaining the choice"
+}
+```
+
+`confidence` is a float in `[0.0, 1.0]`. `reason` MUST be a single short
+sentence (no newlines, no JSON inside).
+
+## User message
+
+{{user_msg}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ orchestrator = "orchestrator.cli:main"
 [project.optional-dependencies]
 dev = [
     "pytest>=8",
+    "pytest>=9.0.3",
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
     "pytest-cov>=5",
     "ruff>=0.6",
     "mypy>=1.10",
@@ -105,6 +108,7 @@ addopts = "-ra --strict-markers -m 'not ollama'"
 markers = [
     "ollama: live evals that hit a local Ollama instance (opt-in via -m ollama)",
 ]
+asyncio_mode = "strict"
 
 [tool.coverage.run]
 source = ["orchestrator", "evals"]

--- a/tests/core/test_classifier.py
+++ b/tests/core/test_classifier.py
@@ -1,0 +1,249 @@
+"""Tests for the intent classifier (#37)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from orchestrator.core.classifier import (
+    ClassifyResult,
+    OllamaClient,
+    StateRecorder,
+    classify,
+)
+
+# --------------------------------------------------------------------------- #
+# Test doubles
+# --------------------------------------------------------------------------- #
+
+
+class FakeOllama:
+    """Returns canned payloads in order; raises if asked beyond what is queued."""
+
+    def __init__(self, responses: Iterable[Any]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def structured(self, *, model: str, schema: type[BaseModel], prompt: str) -> Any:
+        self.calls.append({"model": model, "schema": schema, "prompt": prompt})
+        if not self._responses:
+            raise AssertionError("FakeOllama exhausted")
+        return self._responses.pop(0)
+
+
+class FakeRecorder:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, ClassifyResult]] = []
+
+    def record_classification(self, user_msg: str, result: ClassifyResult) -> None:
+        self.events.append((user_msg, result))
+
+
+def _payload(class_: str, confidence: float, reason: str = "ok") -> str:
+    return json.dumps({"class": class_, "confidence": confidence, "reason": reason})
+
+
+# --------------------------------------------------------------------------- #
+# Pydantic model
+# --------------------------------------------------------------------------- #
+
+
+def test_classify_result_aliases_class() -> None:
+    obj = ClassifyResult.model_validate({"class": "fast", "confidence": 0.9, "reason": "hi"})
+    assert obj.class_ == "fast"
+    dumped = obj.model_dump(by_alias=True)
+    assert dumped["class"] == "fast"
+    assert "class_" not in dumped
+
+
+def test_classify_result_populate_by_name() -> None:
+    obj = ClassifyResult(class_="deep", confidence=0.5, reason="why")
+    assert obj.class_ == "deep"
+
+
+def test_classify_result_rejects_bad_class() -> None:
+    with pytest.raises(ValidationError):
+        ClassifyResult.model_validate({"class": "weird", "confidence": 0.1, "reason": "x"})
+
+
+def test_classify_result_rejects_out_of_range_confidence() -> None:
+    with pytest.raises(ValidationError):
+        ClassifyResult.model_validate({"class": "fast", "confidence": 1.5, "reason": "x"})
+
+
+# --------------------------------------------------------------------------- #
+# Regex pre-filter
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        "status",
+        "  Status please",
+        "What's happening?",
+        "whats happening with my job",
+        "Progress on the build?",
+        "where are we on this",
+    ],
+)
+@pytest.mark.asyncio
+async def test_regex_prefilter_returns_status_without_calling_ollama(
+    msg: str,
+) -> None:
+    ollama = FakeOllama([])  # would raise if called
+    result = await classify(msg, ollama=ollama)  # type: ignore[arg-type]
+    assert result.class_ == "status"
+    assert result.confidence == 1.0
+    assert result.reason == "regex pre-filter"
+    assert ollama.calls == []
+
+
+@pytest.mark.asyncio
+async def test_regex_prefilter_records_to_state() -> None:
+    rec = FakeRecorder()
+    ollama = FakeOllama([])
+    await classify(
+        "status now",
+        ollama=ollama,  # type: ignore[arg-type]
+        recorder=rec,  # type: ignore[arg-type]
+    )
+    assert len(rec.events) == 1
+    assert rec.events[0][1].class_ == "status"
+
+
+# --------------------------------------------------------------------------- #
+# Happy-path model invocation per class
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("class_name", ["fast", "deep", "research", "status"])
+@pytest.mark.asyncio
+async def test_model_path_returns_each_class(class_name: str) -> None:
+    ollama = FakeOllama([_payload(class_name, 0.87, f"{class_name} reason")])
+    result = await classify("please help me with X", ollama=ollama)  # type: ignore[arg-type]
+    assert result.class_ == class_name
+    assert result.confidence == pytest.approx(0.87)
+    assert result.reason == f"{class_name} reason"
+    assert len(ollama.calls) == 1
+    call = ollama.calls[0]
+    assert call["model"] == "qwen2.5:7b"
+    assert call["schema"] is ClassifyResult
+    assert "please help me with X" in call["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_model_path_accepts_dict_payload() -> None:
+    ollama = FakeOllama([{"class": "fast", "confidence": 0.5, "reason": "ok"}])
+    result = await classify("anything", ollama=ollama)  # type: ignore[arg-type]
+    assert result.class_ == "fast"
+
+
+@pytest.mark.asyncio
+async def test_model_path_accepts_bytes_payload() -> None:
+    ollama = FakeOllama([_payload("research", 0.7).encode("utf-8")])
+    result = await classify("dig deeper", ollama=ollama)  # type: ignore[arg-type]
+    assert result.class_ == "research"
+
+
+@pytest.mark.asyncio
+async def test_model_path_accepts_already_validated_result() -> None:
+    canned = ClassifyResult(class_="deep", confidence=0.42, reason="pre-built")
+    ollama = FakeOllama([canned])
+    result = await classify("anything", ollama=ollama)  # type: ignore[arg-type]
+    assert result is canned
+
+
+# --------------------------------------------------------------------------- #
+# Retry / fallback
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_retries_then_succeeds() -> None:
+    ollama = FakeOllama(["not json{{{", _payload("fast", 0.6)])
+    result = await classify("ambiguous", ollama=ollama)  # type: ignore[arg-type]
+    assert result.class_ == "fast"
+    assert len(ollama.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_validation_error_retries_then_succeeds() -> None:
+    bad = json.dumps({"class": "wat", "confidence": 0.5, "reason": "x"})
+    ollama = FakeOllama([bad, _payload("research", 0.9)])
+    result = await classify("ambiguous", ollama=ollama)  # type: ignore[arg-type]
+    assert result.class_ == "research"
+    assert len(ollama.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_two_failures_falls_back_to_deep() -> None:
+    ollama = FakeOllama(["broken", "still broken"])
+    result = await classify("ambiguous", ollama=ollama)  # type: ignore[arg-type]
+    assert result.class_ == "deep"
+    assert result.confidence == 0.0
+    assert result.reason == "classifier fallback"
+    assert len(ollama.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_unexpected_payload_type_falls_back() -> None:
+    ollama = FakeOllama([12345, 67890])  # neither str/bytes/dict/result
+    result = await classify("ambiguous", ollama=ollama)  # type: ignore[arg-type]
+    assert result.class_ == "deep"
+    assert result.reason == "classifier fallback"
+
+
+# --------------------------------------------------------------------------- #
+# State recorder always sees the final decision
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_recorder_called_once_on_model_path() -> None:
+    rec = FakeRecorder()
+    ollama = FakeOllama([_payload("deep", 0.8)])
+    await classify(
+        "refactor this",
+        ollama=ollama,
+        recorder=rec,  # type: ignore[arg-type]
+    )
+    assert len(rec.events) == 1
+    msg, result = rec.events[0]
+    assert msg == "refactor this"
+    assert result.class_ == "deep"
+
+
+@pytest.mark.asyncio
+async def test_recorder_called_once_on_fallback() -> None:
+    rec = FakeRecorder()
+    ollama = FakeOllama(["nope", "still nope"])
+    await classify(
+        "ambiguous",
+        ollama=ollama,  # type: ignore[arg-type]
+        recorder=rec,  # type: ignore[arg-type]
+    )
+    assert len(rec.events) == 1
+    assert rec.events[0][1].reason == "classifier fallback"
+
+
+# --------------------------------------------------------------------------- #
+# Protocol exports remain importable (smoke test for re-export surface)
+# --------------------------------------------------------------------------- #
+
+
+def test_protocols_are_importable() -> None:
+    assert OllamaClient is not None
+    assert StateRecorder is not None
+
+
+def test_classify_reexport_from_core() -> None:
+    from orchestrator.core import ClassifyResult as Re_Result
+    from orchestrator.core import classify as re_classify
+
+    assert Re_Result is ClassifyResult
+    assert re_classify is classify


### PR DESCRIPTION
Closes #37

## Summary
Implements the Phase 3 intent classifier that auto-routes every job to the `fast`, `deep`, `research`, or `status` pipeline.

## What changed
- `orchestrator/core/classifier.py` — async `classify(user_msg, *, ollama, recorder=None)` with the two-tier strategy from the issue.
  - **Tier 1**: regex pre-filter (`^\s*(status|what'?s? happening|progress|where are we)\b`, case-insensitive) returns `class=status`, `confidence=1.0`, `reason=regex pre-filter` without invoking the model.
  - **Tier 2**: structured-output call to `qwen2.5:7b` with the prompt at `orchestrator/prompts/classify.md`.
- `ClassifyResult` Pydantic model with `class_: Literal["fast","deep","research","status"]` aliased to `class`, `confidence: float` (0..1), `reason: str` and `populate_by_name=True`.
- Single retry on malformed JSON / `ValidationError` / unexpected payload type, then deterministic fallback to `deep / 0.0 / "classifier fallback"`.
- `OllamaClient` and `StateRecorder` are `typing.Protocol` — real adapters (#35, #32) wire in without circular imports.
- `orchestrator/prompts/classify.md` versioned prompt with `# classify v1` header.
- `orchestrator/core/__init__.py` re-exports `ClassifyResult` and `classify`.

## Tests
26 new unit tests in `tests/core/test_classifier.py` covering every regex shortcut, every class via a mocked `OllamaClient`, malformed-JSON retry, validation-error retry, unexpected payload type, and the fallback path. No live LLM calls in CI.

## Quality gates
- `ruff check orchestrator tests` — clean
- `pytest --cov=orchestrator` — 301 passed, 1 skipped, **classifier 100%, total 98.85%** (>= 95% required)
- Signed commit (key `9C8C0949390E528F`)
- Conventional Commit title

## Acceptance Criteria met
- [x] `ClassifyResult` Pydantic model with aliased `class` field, `confidence`, `reason`
- [x] `classify` lives in `orchestrator/core/classifier.py`
- [x] Regex pre-filter returns `status` shortcut without calling Ollama
- [x] Otherwise calls `qwen2.5:7b` with the structured prompt
- [x] Invalid output retries once, then falls back to `deep / 0.0`
- [x] Result handed to optional `StateRecorder` for persistence (one event per call)
- [x] Tests cover regex shortcuts, happy-path per class, malformed JSON retry, fallback
- [x] No live LLM calls in CI — `OllamaClient` mocked
