### PR TITLE
docs: rewrite CONTRIBUTING + add DCO + AGENTS.md + tightened PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,50 @@
 <!--
-Thanks for contributing!  Fill out the sections below.
-PR title format: [#<issue>] <type>: <short summary>     e.g. [#12] feat: psutil RAM watchdog
+PR title MUST be a Conventional Commit (it becomes the squash-merge commit):
+  <type>(<optional-scope>): <imperative subject ≤72 chars>
+Allowed types: feat, fix, docs, chore, test, refactor, ops, perf, build, ci, revert.
 -->
 
 ## Linked issue
 
 Closes #
 
-## What this PR does
+<!-- The literal "Closes #<n>" trailer is required so the issue auto-closes on merge. -->
 
-<!-- 2-4 sentences. Focus on user-visible behavior, not implementation. -->
+## Summary
+
+<!-- 2–4 sentences. User-visible behavior, not implementation detail. -->
 
 ## How was it tested?
 
-<!-- Commands you ran. Test files added. Manual verification steps. -->
-
 ```
-pytest tests/<path>
+make lint
+make test
+make cov
 ```
 
-## Checklist
+<!-- Add manual verification steps, screenshots, or sample output if relevant. -->
 
-- [ ] Acceptance Criteria from the linked issue are met
-- [ ] Tests added/updated and passing locally
-- [ ] `ruff check` and `ruff format --check` clean
+## File scope
+
+<!-- Paste the issue's "Files / paths to touch" list. Confirm `git diff --name-only origin/main...HEAD` matches. Justify any deviation. -->
+
+## Checklist (every box must be ticked)
+
+- [ ] PR title is a valid Conventional Commit (`<type>: <subject>`, ≤72 chars)
+- [ ] PR body contains `Closes #<issue>`
+- [ ] **Acceptance Criteria met** — every AC from the linked issue is implemented
+- [ ] Diff stays within the issue's "Files / paths to touch" (deviations justified above)
+- [ ] Every commit is **signed off** (`git commit -s`, DCO trailer present)
+- [ ] Every commit is **GPG- or SSH-signed** (`verified=true` on GitHub)
+- [ ] `ruff check .` and `ruff format --check .` are clean
+- [ ] `pytest --cov=orchestrator --cov-fail-under=95` passes locally — **coverage ≥95%**
+- [ ] Tests added/updated for new behavior
 - [ ] Type hints on public surfaces
-- [ ] No deviations from `docs/PLAN.md` (or plan updated to reflect deviation)
-- [ ] No new dependencies added without justification in the PR description
-- [ ] Architectural rules in `CONTRIBUTING.md` respected (single-LLM slot, checkpointed steps, etc.)
+- [ ] No secrets committed (keys, tokens, `.env` files, fixtures with real creds)
+- [ ] Architectural rules in `CONTRIBUTING.md` respected
+- [ ] No `Co-authored-by: Copilot …` trailer added
+- [ ] Docs updated where behavior changed (or N/A)
 
 ## Notes for reviewers
 
-<!-- Anything tricky, alternatives considered, follow-up issues to file. -->
+<!-- Tricky bits, alternatives considered, follow-up issues to file. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md — rules for AI coding agents
+
+This file is the operating manual for autonomous AI coding agents (Claude
+Code, Copilot CLI, opencode, codex, Cursor, Continue, fleet runners, etc.)
+working on `skgandikota/orchestrator`. Humans should read
+[`CONTRIBUTING.md`](CONTRIBUTING.md) instead — this page is the agent-only
+addendum.
+
+If anything here conflicts with `CONTRIBUTING.md`, `CONTRIBUTING.md` wins.
+
+## Prime directive
+
+**You are the implementer, not the adviser.** Your job is to land working
+code that closes the issue, not to summarize options or ask the user to
+choose. Make a defensible decision, write the code, prove it works, open the
+PR.
+
+## Picking an issue
+
+1. Filter to [`agent-friendly`](../../issues?q=is%3Aopen+is%3Aissue+label%3Aagent-friendly)
+   `+ status:ready`. Skip anything labeled `status:blocked`.
+2. Read the **entire** issue body. Note every Acceptance Criterion and the
+   "Files / paths to touch" list — that list is your file-scope contract.
+3. If the issue says "Blocked by #N" and #N is not closed, stop and pick a
+   different issue. Do not invent dependencies.
+4. Comment `/take` to claim it.
+
+## Implementation contract
+
+Every PR you open must:
+
+- **Implement every Acceptance Criterion.** Partial PRs are rejected.
+- **Stay within file scope.** Only modify files listed in the issue's
+  "Files / paths to touch". If you must deviate, justify it explicitly in
+  the PR body.
+- **Use Conventional Commits** (`feat:`, `fix:`, `docs:`, `chore:`, `test:`,
+  `refactor:`, `ops:`, `ci:`, `build:`, `perf:`). Subject ≤72 chars,
+  imperative mood. The PR title is the squash-merge commit.
+- **Sign off every commit** with `git commit -s` (DCO). CI rejects missing
+  `Signed-off-by:` trailers.
+- **GPG- or SSH-sign every commit.** `main` enforces `required_signatures`.
+- **Keep coverage ≥95%.** Run `pytest --cov=orchestrator --cov-fail-under=95`
+  before pushing. New code without tests fails CI.
+- **Run lint locally.** `ruff check .` and `ruff format --check .` must be
+  clean.
+- **Include `Closes #<issue>`** in the PR body so the issue auto-closes.
+- **Tick every checkbox** in [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+
+## Forbidden
+
+- **Do not add a `Co-authored-by: Copilot …` trailer.** This repo's review
+  stack flags it as a credit-stuffing signal. Sign off as yourself (or as
+  the configured agent identity) and stop there.
+- **Do not commit secrets.** Push protection blocks the obvious cases;
+  scanners (`gitleaks`, `semgrep`) catch the rest. Never paste an API key,
+  even in a test fixture.
+- **Do not touch unrelated files.** Drive-by refactors, formatting sweeps,
+  and "while I was here" cleanups belong in their own issue.
+- **Do not bypass branch protection.** No force-pushes to `main`, no
+  admin-merge, no rewriting history on a shared branch.
+- **Do not weaken the architectural rules** in `CONTRIBUTING.md`
+  (single-LLM slot, status-without-LLM, `job_id` contract, browser
+  drivers as subprocesses, no caller-side provider hardcoding, RAM cap).
+  If a rule is in your way, open a discussion issue first.
+
+## Branching & PR mechanics
+
+```bash
+git checkout -b <type>/<issue>-<slug>     # e.g. feat/42-ram-watchdog
+# … implement …
+git add -A
+git commit -s -S -m "feat: add RAM watchdog (#42)"
+git push -u origin <branch>
+gh pr create \
+  --title "feat: add RAM watchdog" \
+  --body "Closes #42
+
+Acceptance Criteria met."
+```
+
+The PR body must include both `Closes #<issue>` and the literal phrase
+`Acceptance Criteria met` (case-insensitive) — automation greps for them.
+
+## `bot-review-bypass` for config-/docs-only PRs
+
+PRs that touch **only** documentation, GitHub metadata, or non-code config
+(e.g. `*.md`, `.github/**`, `config/**.example`, `Makefile`, `DCO`) may
+apply the `bot-review-bypass` label so the heavy AI review stack stands
+down. Apply it at PR-creation time:
+
+```bash
+gh pr create --label bot-review-bypass --label documentation \
+  --title "docs: …" --body "Closes #N
+
+Acceptance Criteria met."
+```
+
+You are personally responsible for honoring the bypass: if your diff
+touches **any** file under `orchestrator/` or `tests/`, remove the label
+and let the bots review. Misuse is grounds for the strict reviewer to
+block-merge the PR.
+
+## Backing off when blocked
+
+If you cannot make forward progress:
+
+1. Comment on the issue summarizing what you tried, what failed, and the
+   exact error or decision point.
+2. Add label `status:blocked` and remove `status:in-progress`.
+3. Stop. Do not open a half-done PR. Do not invent scope.
+
+## File-scope discipline checklist
+
+Before pushing, run:
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+Cross-reference that list against the issue's "Files / paths to touch".
+Anything extra needs an explicit justification in the PR body or it gets
+reverted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,109 +1,137 @@
-# Contributing to orchestrator
+# Contributing to `orchestrator`
 
-Welcome! This project is **agent-friendly** — issues are written so that humans *and* coding agents (Claude Code, opencode, codex, Cursor, etc.) can pick them up cold and submit a working pull request.
+Welcome — this project is **agent-friendly**. Every issue is written so that
+humans *and* coding agents (Claude Code, Copilot CLI, opencode, codex, Cursor,
+Continue, …) can pick it up cold and submit a working pull request.
 
-## TL;DR for coding agents
+This guide is the single source of truth for how work flows from issue → PR →
+merge. If something here disagrees with another file in the repo, this file
+wins; please open an issue to reconcile.
 
-1. Pick an open issue labeled `status:ready` (no unresolved dependencies).
-2. Read the issue body — every issue includes **Context**, **Files to touch**, **Acceptance Criteria**, and **Definition of Done**.
-3. Read [`docs/PLAN.md`](docs/PLAN.md) for the architecture.
-4. Clone, branch, code, test, PR.
-5. Use the branch name pattern: `<issue-number>-<short-slug>` (e.g. `12-ram-monitor`).
-6. PR title pattern: `[#<issue>] <type>: <short summary>` (e.g. `[#12] feat: psutil RAM watchdog`).
-7. PR body must include `Closes #<issue-number>` so the issue auto-closes on merge.
-8. Keep PRs small and focused on one issue.
+## Project overview
 
-## Workflow
+`orchestrator` is a personal-machine AI orchestrator that splits work between
+free-tier "big" cloud models (planning) and local Ollama models
+(reasoning + execution) without spiking RAM. See [`README.md`](README.md) for
+the high-level pitch and [`docs/PLAN.md`](docs/PLAN.md) for the full design.
 
-```bash
-# 1. Pick an issue (assume #12)
-gh issue view 12
+## Code of Conduct
 
-# 2. Branch
-git checkout -b 12-ram-monitor
+By participating you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md). Report unacceptable behavior via the
+contact listed there.
 
-# 3. Code + tests
-# ... make your changes ...
-
-# 4. Run checks (once tooling lands in Phase 1)
-ruff check .
-ruff format --check .
-pytest
-
-# 5. Commit, push, PR
-git add -A
-git commit -m "[#12] feat: psutil RAM watchdog with soft/hard caps"
-git push -u origin 12-ram-monitor
-gh pr create --fill --body "Closes #12"
-```
-
-## Issue labels — quick reference
-
-**Phase** (which milestone this belongs to):
-`phase:1-foundations` · `phase:2-providers` · `phase:3-pipeline` · `phase:4-tools` · `phase:5-interfaces` · `phase:6-status` · `phase:7-hardening`
-
-**Type** (what kind of work):
-`type:feat` · `type:test` · `type:docs` · `type:chore` · `type:research` · `type:bug`
-
-**Area** (which subsystem):
-`area:core` · `area:models` · `area:tools` · `area:interfaces` · `area:prompts` · `area:config`
-
-**Priority**:
-`priority:p0-blocker` · `priority:p1-high` · `priority:p2-normal` · `priority:p3-low`
-
-**Status**:
-`status:ready` (no blockers, pick me up!) · `status:blocked` (waiting on a dependency) · `status:in-progress`
-
-**Special**:
-`good-first-issue` · `help-wanted` · `agent-friendly` · `epic`
-
-## Code style
-
-- **Python 3.11+**.
-- Format with `ruff format` (PEP 8, line length 100).
-- Lint with `ruff check`.
-- Type hints on all public functions; check with `mypy` in strict mode for new modules where possible.
-- Docstrings: short, useful — no boilerplate. Document non-obvious behavior, not signatures.
-- Tests use `pytest`. Aim for behavior-level tests, not implementation-bound.
-
-## Project structure
-
-See [`docs/PLAN.md`](docs/PLAN.md#high-level-architecture). In short:
-
-```
-orchestrator/
-├── core/         # scheduler, state, pipeline, ram_monitor, classifier
-├── models/       # ollama_local, big_ai/, narrator
-├── tools/        # fs, shell, web, browser, git, registry
-├── interfaces/   # openai_compat, mcp_server, http_api, cli
-├── prompts/      # versioned prompt templates
-└── tests/
-```
-
-## Testing rules
-
-- **Unit tests** for pure logic — no model calls, no network.
-- **Integration tests** that need Ollama: mark with `@pytest.mark.ollama` and skip by default in CI.
-- **Integration tests** that need API keys: mark with `@pytest.mark.live` and skip by default.
-- Mock all big-AI providers via `litellm` mock backends in unit tests.
-- **Coverage gate:** `pytest --cov=orchestrator --cov-fail-under=95` is enforced in CI. PRs that drop coverage below 95% will fail. Use `# pragma: no cover` only for genuinely-untestable branches (e.g. real subprocess fork paths).
-
-## Signed commits (mandatory)
-
-The `main` branch enforces `required_signatures` via a repository ruleset. **Every commit must be GPG- or SSH-signed**, otherwise push and merge are blocked.
-
-One-time setup:
+## Quick start
 
 ```bash
-# Option A: GPG
+git clone https://github.com/skgandikota/orchestrator.git
+cd orchestrator
+python -m venv .venv && source .venv/bin/activate    # Windows: .venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
+make test
+```
+
+Full local-development walkthrough — Ollama setup, browser drivers,
+environment variables, debugging tips — lives in
+[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
+
+## Issue workflow
+
+1. Browse the [`agent-friendly`](../../issues?q=is%3Aopen+is%3Aissue+label%3Aagent-friendly)
+   or [`status:ready`](../../issues?q=is%3Aopen+is%3Aissue+label%3Astatus%3Aready)
+   filters — these issues have no unresolved blockers.
+2. Comment **`/take`** on the issue to claim it (prevents duplicate work).
+3. Read the issue end-to-end. Every issue ships with **Context**,
+   **Files / paths to touch**, **Acceptance Criteria**, and
+   **Definition of Done**. Implement *every* AC.
+4. Stick to the listed file scope. If you must touch something else, say so in
+   the PR description and explain why.
+
+### Label cheat sheet
+
+| Group | Labels |
+|---|---|
+| Phase | `phase:1-foundations` … `phase:7-hardening` |
+| Type | `type:feat` `type:fix` `type:docs` `type:chore` `type:test` `type:refactor` `type:research` |
+| Area | `area:core` `area:models` `area:tools` `area:interfaces` `area:prompts` `area:config` |
+| Priority | `priority:p0-blocker` `priority:p1-high` `priority:p2-normal` `priority:p3-low` |
+| Status | `status:ready` `status:in-progress` `status:blocked` |
+| Special | `agent-friendly` `good-first-issue` `help-wanted` `epic` `bot-review-bypass` |
+
+## Branching model
+
+Branch names follow `<type>/<issue>-<short-slug>`:
+
+```
+feat/42-ram-watchdog
+fix/57-classifier-timeout
+docs/50-contrib-dco-agents
+chore/61-dependabot-grouping
+ops/52-make-targets
+```
+
+`<type>` mirrors the Conventional Commit type (see below). One issue per
+branch, one branch per PR.
+
+## Commit conventions
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional-scope>): <imperative subject ≤72 chars>
+
+<body wrapped at 80 cols, explaining *why* not *what*>
+
+Closes #<issue>
+Signed-off-by: Your Name <you@example.com>
+```
+
+Allowed types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `ops`,
+`perf`, `build`, `ci`, `revert`.
+
+The PR title **must** be a valid Conventional Commit message — it becomes the
+squash-merge commit.
+
+## DCO sign-off (mandatory)
+
+Every commit must carry a `Signed-off-by:` trailer asserting the
+[Developer Certificate of Origin v1.1](DCO). Run:
+
+```bash
+git commit -s -m "feat: add RAM watchdog"
+```
+
+CI rejects PRs whose commits are missing a `Signed-off-by:` line. We enforce
+DCO because this project is licensed under
+[CC BY-NC-SA 4.0](LICENSE) — sign-off keeps the provenance of contributions
+unambiguous and protects everyone downstream.
+
+To retro-sign an existing branch:
+
+```bash
+git rebase --signoff main
+git push --force-with-lease
+```
+
+## GPG-signed commits (mandatory)
+
+The `main` branch enforces `required_signatures` via a repository ruleset.
+Every commit must be GPG- or SSH-signed; unsigned pushes are rejected.
+
+One-time setup (GPG):
+
+```bash
 gpg --full-generate-key                          # ed25519 or rsa4096
 gpg --list-secret-keys --keyid-format=long       # copy KEYID
 git config --global user.signingkey <KEYID>
 git config --global commit.gpgsign true
 git config --global tag.gpgsign true
 gpg --armor --export <KEYID>                     # paste at https://github.com/settings/gpg/new
+```
 
-# Option B: SSH (simpler, uses existing ~/.ssh/id_ed25519)
+Or SSH (simpler, reuses `~/.ssh/id_ed25519`):
+
+```bash
 git config --global gpg.format ssh
 git config --global user.signingkey ~/.ssh/id_ed25519.pub
 git config --global commit.gpgsign true
@@ -111,41 +139,108 @@ git config --global commit.gpgsign true
 ```
 
 Verify:
+
 ```bash
 git log --show-signature -1
 gh api /repos/skgandikota/orchestrator/commits/<sha> --jq '.commit.verification'
 # expect: verified=true, reason=valid
 ```
 
-Bots (GitHub Apps) sign automatically with GitHub's web-flow signature when committing via the API. No setup needed for the strict reviewer's squash-merge.
+GitHub Apps (bots) sign automatically with GitHub's web-flow signature.
 
-## Definition of Done (applies to every issue)
+## Pull-request process
 
-A PR is mergeable when:
+1. Push your branch and open a PR against `main`.
+2. The PR title must be a Conventional Commit (`<type>: <subject>`).
+3. The PR body must include `Closes #<issue>` so the issue auto-closes on merge.
+4. Fill out [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)
+   in full — every checkbox is load-bearing.
+5. Keep PRs **small and focused**: one issue per PR. Draft PRs are welcome
+   while you iterate.
+6. Re-running CI without changes? Push an empty signed commit:
+   `git commit --allow-empty -s -m "ci: rerun"`.
 
-1. Code implements the **Acceptance Criteria** in the issue.
-2. Tests for the new behavior exist and pass locally (`pytest`).
-3. `ruff check` and `ruff format --check` pass.
-4. **Coverage stays at or above 95%** (`--cov-fail-under=95` in CI).
-5. **Every commit on the branch is signed** (`verified=true` on GitHub).
-6. Public APIs have type hints.
-7. Docs/`docs/PLAN.md` updated **only if the change deviates from the plan** — otherwise leave the plan alone.
-8. PR body says `Closes #<issue-number>`.
+### Config-/docs-only PRs
+
+PRs that only touch documentation, configuration, GitHub metadata, or other
+non-code surfaces may apply the **`bot-review-bypass`** label to skip the
+heavier AI review stack. Code changes (anything under `orchestrator/` or
+`tests/`) **must not** use this bypass.
+
+## Review process
+
+- [`@skgandikota`](https://github.com/skgandikota) is a code owner and is
+  auto-assigned via [`.github/CODEOWNERS`](.github/CODEOWNERS).
+- A layered AI review stack runs on every PR — see
+  [`docs/REVIEW_BOTS.md`](docs/REVIEW_BOTS.md) and
+  [`.github/review-bots.yml`](.github/review-bots.yml). Only the strict
+  `code-reviewer-001` bot has merge authority; it waits for the advisory
+  bots (CodeRabbit, Sourcery, PR-Agent, Gemini, Copilot) to weigh in before
+  approving or requesting changes.
+- At least **one approving review** is required.
+- Stale reviews are dismissed automatically when new commits are pushed.
+- The last pusher cannot self-approve.
+- Address every actionable comment with either a code change or a reasoned
+  reply; do not silently resolve threads.
+
+## Build, test, lint
+
+Canonical commands (all defined in the [`Makefile`](Makefile)):
+
+```bash
+make lint        # ruff check + ruff format --check
+make typecheck   # mypy on changed modules
+make test        # pytest
+make cov         # pytest with coverage gate
+```
+
+**Coverage gate: 95%.** CI runs
+`pytest --cov=orchestrator --cov-fail-under=95`. PRs that drop coverage below
+95% fail. Use `# pragma: no cover` only for genuinely-untestable branches
+(real subprocess fork paths, platform-specific stubs, etc.).
+
+Test conventions:
+
+- **Unit** tests are pure: no model calls, no network.
+- **Ollama** integration tests use `@pytest.mark.ollama` (skipped by default).
+- **Live API** tests use `@pytest.mark.live` (skipped by default).
+- Mock big-AI providers via `litellm` mock backends.
 
 ## Architectural rules of the road
 
 These are non-negotiable for any change:
 
-1. **Never load two 7B models simultaneously.** Always go through `core.scheduler`.
-2. **Every coder step is a checkpoint** — write progress to SQLite before yielding the slot.
-3. **Status queries must not require an LLM** by default — read from SQLite first.
-4. **All long-running work is a job with an ID.** APIs return `job_id` immediately; clients stream/poll.
-5. **Provider fallback is automatic** — no caller should hardcode a provider.
-6. **Browser drivers are separate subprocesses** — never in-process with the main app.
-7. **One external model name: `orchestrator`.** The classifier picks the pipeline, not the user.
+```
+1. Never load two 7B models simultaneously. Always go through core.scheduler.
+2. Every coder step is a checkpoint — write progress to SQLite before yielding the slot.
+3. Status queries must not require an LLM by default — read from SQLite first.
+4. All long-running work is a job with an ID. APIs return job_id immediately; clients stream/poll.
+5. Provider fallback is automatic — no caller hardcodes a provider.
+6. Browser drivers are separate subprocesses — never in-process with the main app.
+7. One external model name: orchestrator. The classifier picks the pipeline, not the user.
+8. Honor the RAM cap. psutil-based watchdog must be respected by every subprocess.
+```
 
-If your change conflicts with one of these, open a discussion issue before coding.
+If your change conflicts with any of these, open a discussion issue first.
+
+## Security
+
+- **Never commit secrets.** Push protection is enabled but treat it as a
+  safety net, not a substitute for review.
+- Report vulnerabilities privately per [`SECURITY.md`](SECURITY.md).
+- Scanners that gate `main`: `ruff`, `mypy`, `pytest --cov`, `gitleaks`,
+  `semgrep`, `trivy`, DCO. See
+  [`.github/branch-protection.md`](.github/branch-protection.md) for the
+  authoritative list.
+
+## License & contribution terms
+
+By submitting a pull request you agree your contribution is licensed under
+[CC BY-NC-SA 4.0](LICENSE). That means downstream users may share and adapt
+your work non-commercially, attributing you and re-sharing under the same
+terms. Sign-off (the DCO) is your assertion that you have the right to make
+that grant.
 
 ## Questions?
 
-Open a [Question issue](../../issues/new?template=question.yml) or comment on the issue you're working on. We'll respond.
+Open an issue or comment on the one you're working on. We answer.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Closes #50

## Summary

Rewrites the contributor docs as part of Phase 7 hardening:

- **CONTRIBUTING.md** — full rewrite covering project overview, Code of Conduct ref, quick-start (linking `docs/DEVELOPMENT.md`), issue workflow, branching model (`<type>/<issue>-<slug>`), Conventional Commits, DCO sign-off, GPG/SSH signing, PR process, layered AI review-bot stack, `make` targets, the 95% coverage gate, architectural rules, security, and license/contribution terms.
- **DCO** — Developer Certificate of Origin v1.1 verbatim, referenced from the sign-off section.
- **AGENTS.md** — concise operating manual for AI coding agents: prime directive (implementer, not adviser), Acceptance-Criteria discipline, Conventional Commits, signed commits, 95% coverage, no `Co-authored-by: Copilot` trailer, file-scope discipline, and how/when to apply `bot-review-bypass` on config-/docs-only PRs.
- **.github/PULL_REQUEST_TEMPLATE.md** — tightened: `Closes #N` required, Conventional Commit title check, **Acceptance Criteria met** checkbox, DCO + GPG sign-off checkboxes, coverage statement, file-scope statement, no-secrets and no-Copilot-coauthor checks.

## File scope

- `CONTRIBUTING.md`
- `DCO`
- `AGENTS.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

This is a docs-/config-only PR — applying `bot-review-bypass`. No files under `orchestrator/`, `tests/`, `pyproject.toml`, or `.github/workflows/` are touched.

Acceptance Criteria met.
