### PR TITLE
feat(providers): provider fallback chain with circuit breaker

### DIFF
--- a/orchestrator/providers/__init__.py
+++ b/orchestrator/providers/__init__.py
@@ -1,0 +1,35 @@
+"""Provider fallback chain with per-provider circuit breaker.
+
+The :mod:`orchestrator.providers.fallback` module is the public surface; this
+package exists so the chain can grow alongside concrete provider adapters
+(LiteLLM router from #8, Playwright browser driver from #9) without breaking
+imports.
+"""
+
+from orchestrator.providers.fallback import (
+    AllProvidersFailed,
+    AuthError,
+    BrowserDriverCrashed,
+    BrowserProvider,
+    CircuitBreaker,
+    CircuitState,
+    FallbackChain,
+    InvalidRequest,
+    Provider,
+    ProviderUnavailable,
+    QuotaExceeded,
+)
+
+__all__ = [
+    "AllProvidersFailed",
+    "AuthError",
+    "BrowserDriverCrashed",
+    "BrowserProvider",
+    "CircuitBreaker",
+    "CircuitState",
+    "FallbackChain",
+    "InvalidRequest",
+    "Provider",
+    "ProviderUnavailable",
+    "QuotaExceeded",
+]

--- a/orchestrator/providers/fallback.py
+++ b/orchestrator/providers/fallback.py
@@ -1,0 +1,401 @@
+"""Provider fallback chain with per-provider circuit breaker.
+
+This module implements the architectural rule from ``docs/PLAN.md`` §7:
+
+    Provider fallback is automatic: API quota exhausted -> next API
+    -> browser driver as last resort.
+
+Design
+------
+
+* :class:`FallbackChain` wraps an ordered list of providers (matching the
+  :class:`Provider` :class:`typing.Protocol`) and tries each in turn until one
+  returns a result or the chain is exhausted.
+* Each provider has an independent :class:`CircuitBreaker`. The breaker opens
+  after ``failure_threshold`` consecutive failures; while open the provider is
+  skipped until the ``cooldown`` elapses, after which it transitions to
+  ``HALF_OPEN`` and is given exactly one trial request. A success closes the
+  breaker; a failure re-opens it.
+* Failure classification is deliberate. **Transient** failures
+  (:class:`QuotaExceeded`, :class:`ProviderUnavailable`,
+  :class:`BrowserDriverCrashed`, :class:`TimeoutError`,
+  :class:`ConnectionError`, ``httpx.HTTPError`` if installed) cause fall-through
+  to the next provider. **Terminal** failures (:class:`AuthError`,
+  :class:`InvalidRequest`) abort the chain immediately - retrying them on a
+  different provider would just leak the same bad credentials / bad payload.
+* Browser providers (:class:`BrowserProvider`) are only attempted after every
+  API provider has failed, and only when ``browser_as_last_resort=True``. They
+  are kept behind a :class:`typing.Protocol` so this module does not depend on
+  Playwright or the in-flight #9 implementation.
+* Every attempt, success, fall-through, and terminal failure is emitted as an
+  :mod:`orchestrator.observability.audit` event so operators can see the chain
+  in production.
+
+The provider interface is a :class:`typing.Protocol` so the unit tests
+intentionally do **not** depend on the LiteLLM router landing in #8; integration
+happens on rebase or in a follow-up.
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from orchestrator.observability import audit
+
+__all__ = [
+    "AllProvidersFailed",
+    "AuthError",
+    "BrowserDriverCrashed",
+    "BrowserProvider",
+    "CircuitBreaker",
+    "CircuitState",
+    "FallbackChain",
+    "InvalidRequest",
+    "Provider",
+    "ProviderUnavailable",
+    "QuotaExceeded",
+]
+
+
+# --- Errors -----------------------------------------------------------------
+
+
+class ProviderError(Exception):
+    """Base class for all provider-related errors raised by this package."""
+
+
+class QuotaExceeded(ProviderError):
+    """The provider rejected the request because a rate or quota limit was hit.
+
+    Mirrors the error type defined by the LiteLLM router in #8 so callers can
+    catch a single name once both PRs land.
+    """
+
+
+class ProviderUnavailable(ProviderError):
+    """The provider failed transiently (5xx, network blip, timeout)."""
+
+
+class BrowserDriverCrashed(ProviderError):
+    """The browser-driven provider subprocess died mid-request."""
+
+
+class AuthError(ProviderError):
+    """Authentication / authorization failed (401, 403). Do **not** retry."""
+
+
+class InvalidRequest(ProviderError):
+    """The request itself was malformed (400). Do **not** retry."""
+
+
+@dataclass
+class AllProvidersFailed(ProviderError):
+    """Raised when the chain is exhausted without a successful response.
+
+    Attributes:
+        failures: Ordered list of ``(provider_id, exception)`` tuples, one per
+            provider that was attempted.
+    """
+
+    failures: list[tuple[str, BaseException]] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        if not self.failures:
+            return "AllProvidersFailed: no providers were attempted"
+        parts = [f"{pid}: {type(exc).__name__}: {exc}" for pid, exc in self.failures]
+        return "AllProvidersFailed: " + "; ".join(parts)
+
+
+# Failure classes that should cause the chain to advance to the next provider.
+# ``httpx.HTTPError`` is added dynamically below if httpx is importable so we
+# do not hard-depend on it in environments that strip it.
+_FALLTHROUGH_ERRORS: tuple[type[BaseException], ...] = (
+    QuotaExceeded,
+    ProviderUnavailable,
+    BrowserDriverCrashed,
+    TimeoutError,
+    ConnectionError,
+)
+
+try:
+    import httpx as _httpx
+
+    _FALLTHROUGH_ERRORS = (*_FALLTHROUGH_ERRORS, _httpx.HTTPError)
+except ImportError:  # pragma: no cover - defensive
+    pass
+
+# Failure classes that should abort the chain immediately.
+_TERMINAL_ERRORS: tuple[type[BaseException], ...] = (AuthError, InvalidRequest)
+
+
+# --- Provider protocols -----------------------------------------------------
+
+
+@runtime_checkable
+class Provider(Protocol):
+    """Minimum interface a provider must satisfy to participate in a chain.
+
+    The :attr:`id` is used for audit/log correlation and as the circuit-breaker
+    key; it must be stable and unique within a chain.
+    """
+
+    id: str
+
+    def complete(self, messages: Sequence[dict[str, Any]], **kwargs: Any) -> Any:
+        """Run a chat completion. Raise a :class:`ProviderError` on failure."""
+
+
+@runtime_checkable
+class BrowserProvider(Provider, Protocol):
+    """Marker protocol for providers driven by a browser subprocess (#9)."""
+
+
+# --- Circuit breaker --------------------------------------------------------
+
+
+class CircuitState(enum.StrEnum):
+    """Three-state circuit breaker as described in Nygard, *Release It!*."""
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitBreaker:
+    """Per-provider failure counter that short-circuits broken providers.
+
+    The breaker is **closed** in steady state - all calls go through. After
+    ``failure_threshold`` consecutive failures it transitions to **open**;
+    :meth:`allow` returns ``False`` for the next ``cooldown`` seconds, causing
+    :class:`FallbackChain` to skip the provider entirely. Once the cooldown has
+    elapsed the next :meth:`allow` call flips the breaker to **half-open** and
+    permits a single trial request: a success on that trial closes the breaker
+    and resets the failure counter, while a failure immediately re-opens it for
+    another full cooldown.
+    """
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: int = 3,
+        cooldown_seconds: float = 60.0,
+        clock: Any = time.monotonic,
+    ) -> None:
+        if failure_threshold < 1:
+            raise ValueError("failure_threshold must be >= 1")
+        if cooldown_seconds < 0:
+            raise ValueError("cooldown_seconds must be >= 0")
+        self.failure_threshold = failure_threshold
+        self.cooldown_seconds = cooldown_seconds
+        self._clock = clock
+        self._state: CircuitState = CircuitState.CLOSED
+        self._failures = 0
+        self._opened_at: float | None = None
+
+    @property
+    def state(self) -> CircuitState:
+        return self._state
+
+    @property
+    def failures(self) -> int:
+        return self._failures
+
+    def allow(self) -> bool:
+        """Return ``True`` if a request should be attempted right now."""
+        if self._state is CircuitState.CLOSED:
+            return True
+        if self._state is CircuitState.OPEN:
+            if self._opened_at is None:
+                return True
+            if self._clock() - self._opened_at >= self.cooldown_seconds:
+                self._state = CircuitState.HALF_OPEN
+                return True
+            return False
+        return True
+
+    def record_success(self) -> None:
+        self._state = CircuitState.CLOSED
+        self._failures = 0
+        self._opened_at = None
+
+    def record_failure(self) -> None:
+        self._failures += 1
+        if self._state is CircuitState.HALF_OPEN or self._failures >= self.failure_threshold:
+            self._state = CircuitState.OPEN
+            self._opened_at = self._clock()
+
+
+# --- Fallback chain ---------------------------------------------------------
+
+
+class FallbackChain:
+    """Ordered chain of providers with per-provider circuit breakers.
+
+    Args:
+        providers: Ordered list of :class:`Provider` instances. The first one
+            that succeeds wins.
+        browser_provider: Optional :class:`BrowserProvider` invoked only after
+            every entry in ``providers`` has failed.
+        browser_as_last_resort: If ``False`` the ``browser_provider`` is never
+            invoked even when set; matches the ``[providers]`` settings flag.
+        failure_threshold: Consecutive failures required to trip a breaker.
+        cooldown_seconds: How long a tripped breaker stays open.
+        actor: Audit-log ``actor`` field; defaults to ``"providers.fallback"``.
+        clock: Monotonic clock injected for deterministic tests.
+    """
+
+    def __init__(
+        self,
+        providers: Sequence[Provider],
+        *,
+        browser_provider: BrowserProvider | None = None,
+        browser_as_last_resort: bool = True,
+        failure_threshold: int = 3,
+        cooldown_seconds: float = 60.0,
+        actor: str = "providers.fallback",
+        clock: Any = time.monotonic,
+    ) -> None:
+        if not providers and browser_provider is None:
+            raise ValueError("FallbackChain requires at least one provider")
+        self._providers: tuple[Provider, ...] = tuple(providers)
+        self._browser_provider = browser_provider
+        self._browser_as_last_resort = browser_as_last_resort
+        self._actor = actor
+        self._breakers: dict[str, CircuitBreaker] = {
+            p.id: CircuitBreaker(
+                failure_threshold=failure_threshold,
+                cooldown_seconds=cooldown_seconds,
+                clock=clock,
+            )
+            for p in self._providers
+        }
+        if browser_provider is not None:
+            self._breakers[browser_provider.id] = CircuitBreaker(
+                failure_threshold=failure_threshold,
+                cooldown_seconds=cooldown_seconds,
+                clock=clock,
+            )
+
+    # --- introspection ----------------------------------------------------
+
+    def breaker(self, provider_id: str) -> CircuitBreaker:
+        """Return the circuit breaker for ``provider_id`` (test helper)."""
+        return self._breakers[provider_id]
+
+    @property
+    def provider_ids(self) -> tuple[str, ...]:
+        return tuple(p.id for p in self._providers)
+
+    # --- main entry point -------------------------------------------------
+
+    def complete(
+        self,
+        messages: Sequence[dict[str, Any]],
+        **kwargs: Any,
+    ) -> Any:
+        """Try each provider in order; return the first successful response.
+
+        Raises:
+            AuthError / InvalidRequest: Re-raised immediately - these are
+                terminal and would fail on every provider in the chain.
+            AllProvidersFailed: All providers failed transiently; the
+                ``failures`` attribute carries one ``(id, exc)`` tuple per
+                provider that was attempted (skipped-by-breaker entries are
+                included with a synthetic :class:`ProviderUnavailable`).
+        """
+        failures: list[tuple[str, BaseException]] = []
+
+        for provider in self._providers:
+            outcome = self._attempt(provider, messages, kwargs, failures)
+            if outcome is not _MISS:
+                return outcome
+
+        if self._browser_provider is not None and self._browser_as_last_resort:
+            outcome = self._attempt(self._browser_provider, messages, kwargs, failures)
+            if outcome is not _MISS:
+                return outcome
+
+        err = AllProvidersFailed(failures=failures)
+        audit.record(
+            actor=self._actor,
+            action="chain_failed",
+            target=None,
+            status="error",
+            payload={"failures": [(pid, repr(exc)) for pid, exc in failures]},
+        )
+        raise err
+
+    # --- internals --------------------------------------------------------
+
+    def _attempt(
+        self,
+        provider: Provider,
+        messages: Sequence[dict[str, Any]],
+        kwargs: dict[str, Any],
+        failures: list[tuple[str, BaseException]],
+    ) -> Any:
+        breaker = self._breakers[provider.id]
+        if not breaker.allow():
+            skip_exc = ProviderUnavailable(f"circuit breaker OPEN for {provider.id!r}")
+            failures.append((provider.id, skip_exc))
+            audit.record(
+                actor=self._actor,
+                action="provider_skipped",
+                target=provider.id,
+                status="warn",
+                payload={"reason": "circuit_open"},
+            )
+            return _MISS
+
+        audit.record(
+            actor=self._actor,
+            action="provider_attempt",
+            target=provider.id,
+            status="ok",
+            payload={"breaker_state": breaker.state.value},
+        )
+        try:
+            result = provider.complete(messages, **kwargs)
+        except _TERMINAL_ERRORS as exc:
+            audit.record(
+                actor=self._actor,
+                action="provider_failed_terminal",
+                target=provider.id,
+                status="error",
+                payload={"error": type(exc).__name__, "message": str(exc)},
+            )
+            raise
+        except _FALLTHROUGH_ERRORS as exc:
+            breaker.record_failure()
+            failures.append((provider.id, exc))
+            audit.record(
+                actor=self._actor,
+                action="provider_fallthrough",
+                target=provider.id,
+                status="warn",
+                payload={
+                    "error": type(exc).__name__,
+                    "message": str(exc),
+                    "breaker_state": breaker.state.value,
+                },
+            )
+            return _MISS
+
+        breaker.record_success()
+        audit.record(
+            actor=self._actor,
+            action="provider_success",
+            target=provider.id,
+            status="ok",
+        )
+        return result
+
+
+# Sentinel returned by :meth:`FallbackChain._attempt` to signal "no result yet,
+# keep walking the chain". ``None`` is a perfectly valid provider response so we
+# need a dedicated marker.
+_MISS: Any = object()

--- a/tests/providers/test_fallback.py
+++ b/tests/providers/test_fallback.py
@@ -1,0 +1,338 @@
+"""Tests for :mod:`orchestrator.providers.fallback`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+
+from orchestrator.observability import audit
+from orchestrator.providers.fallback import (
+    AllProvidersFailed,
+    AuthError,
+    BrowserDriverCrashed,
+    CircuitBreaker,
+    CircuitState,
+    FallbackChain,
+    InvalidRequest,
+    ProviderUnavailable,
+    QuotaExceeded,
+)
+
+# --- Test doubles -----------------------------------------------------------
+
+
+class StubProvider:
+    """A scriptable provider whose ``complete`` returns/raises in sequence.
+
+    Each entry in ``script`` is either a value to return or an exception to
+    raise. The provider records every call in ``calls`` for assertions.
+    """
+
+    def __init__(self, provider_id: str, script: list[Any]) -> None:
+        self.id = provider_id
+        self.script = list(script)
+        self.calls: list[tuple[Sequence[dict[str, Any]], dict[str, Any]]] = []
+
+    def complete(self, messages: Sequence[dict[str, Any]], **kwargs: Any) -> Any:
+        self.calls.append((messages, kwargs))
+        if not self.script:
+            raise AssertionError(f"{self.id} called more than scripted")
+        item = self.script.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+class FakeClock:
+    """Manually advanced monotonic clock for deterministic breaker tests."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_audit_log(tmp_path: Any) -> Any:
+    """Each test gets its own audit log so events do not bleed between tests.
+
+    Uses a tmp-file SQLite database (not ``:memory:``) because the audit
+    writer thread opens its own connection and ``:memory:`` databases are
+    per-connection.
+    """
+    log = audit.AuditLog(str(tmp_path / "audit.db"))
+    audit.configure_default_log(log)
+    try:
+        yield log
+    finally:
+        audit.reset_default_log()
+
+
+# --- CircuitBreaker ---------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    def test_validates_args(self) -> None:
+        with pytest.raises(ValueError):
+            CircuitBreaker(failure_threshold=0)
+        with pytest.raises(ValueError):
+            CircuitBreaker(cooldown_seconds=-1)
+
+    def test_starts_closed_and_allows(self) -> None:
+        cb = CircuitBreaker()
+        assert cb.state is CircuitState.CLOSED
+        assert cb.allow() is True
+        assert cb.failures == 0
+
+    def test_opens_after_threshold(self) -> None:
+        clock = FakeClock()
+        cb = CircuitBreaker(failure_threshold=2, cooldown_seconds=10, clock=clock)
+        cb.record_failure()
+        assert cb.state is CircuitState.CLOSED
+        cb.record_failure()
+        assert cb.state is CircuitState.OPEN
+        assert cb.allow() is False
+
+    def test_half_open_after_cooldown_then_closes_on_success(self) -> None:
+        clock = FakeClock()
+        cb = CircuitBreaker(failure_threshold=1, cooldown_seconds=5, clock=clock)
+        cb.record_failure()
+        assert cb.state is CircuitState.OPEN
+        assert cb.allow() is False
+
+        clock.advance(5)
+        assert cb.allow() is True
+        assert cb.state is CircuitState.HALF_OPEN
+        cb.record_success()
+        assert cb.state is CircuitState.CLOSED
+        assert cb.failures == 0
+
+    def test_half_open_failure_reopens(self) -> None:
+        clock = FakeClock()
+        cb = CircuitBreaker(failure_threshold=1, cooldown_seconds=5, clock=clock)
+        cb.record_failure()
+        clock.advance(5)
+        cb.allow()
+        assert cb.state is CircuitState.HALF_OPEN
+        cb.record_failure()
+        assert cb.state is CircuitState.OPEN
+        assert cb.allow() is False
+
+
+# --- FallbackChain ----------------------------------------------------------
+
+
+def _msgs() -> list[dict[str, Any]]:
+    return [{"role": "user", "content": "hi"}]
+
+
+class TestFallbackChain:
+    def test_requires_at_least_one_provider(self) -> None:
+        with pytest.raises(ValueError):
+            FallbackChain([])
+
+    def test_first_provider_wins(self, _isolated_audit_log: audit.AuditLog) -> None:
+        a = StubProvider("a", ["alpha"])
+        b = StubProvider("b", ["beta"])
+        chain = FallbackChain([a, b])
+
+        result = chain.complete(_msgs())
+
+        assert result == "alpha"
+        assert len(a.calls) == 1
+        assert b.calls == []
+        _isolated_audit_log.close()
+        successes = _isolated_audit_log.query(action="provider_success")
+        assert any(e.target == "a" for e in successes)
+
+    def test_fallthrough_on_quota(self, _isolated_audit_log: audit.AuditLog) -> None:
+        a = StubProvider("a", [QuotaExceeded("rate limit")])
+        b = StubProvider("b", ["beta"])
+        chain = FallbackChain([a, b])
+
+        result = chain.complete(_msgs())
+
+        assert result == "beta"
+        assert len(a.calls) == 1
+        assert len(b.calls) == 1
+        _isolated_audit_log.close()
+        ft = _isolated_audit_log.query(action="provider_fallthrough")
+        assert any(e.target == "a" for e in ft)
+
+    def test_fallthrough_on_5xx_timeout_network(self) -> None:
+        a = StubProvider("a", [ProviderUnavailable("503")])
+        b = StubProvider("b", [TimeoutError("slow")])
+        c = StubProvider("c", [ConnectionError("reset")])
+        d = StubProvider("d", ["ok"])
+        chain = FallbackChain([a, b, c, d])
+
+        assert chain.complete(_msgs()) == "ok"
+
+    def test_all_fail_bubbles_up(self, _isolated_audit_log: audit.AuditLog) -> None:
+        a = StubProvider("a", [QuotaExceeded("q")])
+        b = StubProvider("b", [ProviderUnavailable("u")])
+        chain = FallbackChain([a, b])
+
+        with pytest.raises(AllProvidersFailed) as excinfo:
+            chain.complete(_msgs())
+
+        ids = [pid for pid, _ in excinfo.value.failures]
+        assert ids == ["a", "b"]
+        # human readable
+        assert "a:" in str(excinfo.value) and "b:" in str(excinfo.value)
+        _isolated_audit_log.close()
+        assert _isolated_audit_log.query(action="chain_failed")
+
+    def test_empty_failures_str(self) -> None:
+        err = AllProvidersFailed()
+        assert "no providers" in str(err)
+
+    def test_fail_fast_on_auth_error(self) -> None:
+        a = StubProvider("a", [AuthError("401")])
+        b = StubProvider("b", ["never"])
+        chain = FallbackChain([a, b])
+
+        with pytest.raises(AuthError):
+            chain.complete(_msgs())
+
+        assert b.calls == []  # second provider must not be tried
+
+    def test_fail_fast_on_invalid_request(self) -> None:
+        a = StubProvider("a", [InvalidRequest("400")])
+        b = StubProvider("b", ["never"])
+        chain = FallbackChain([a, b])
+
+        with pytest.raises(InvalidRequest):
+            chain.complete(_msgs())
+        assert b.calls == []
+
+    def test_browser_fallback_called_when_enabled(self) -> None:
+        a = StubProvider("a", [QuotaExceeded("q")])
+        browser = StubProvider("browser", ["from-browser"])
+        chain = FallbackChain([a], browser_provider=browser)
+
+        assert chain.complete(_msgs()) == "from-browser"
+        assert len(browser.calls) == 1
+
+    def test_browser_skipped_when_flag_off(self) -> None:
+        a = StubProvider("a", [QuotaExceeded("q")])
+        browser = StubProvider("browser", ["never"])
+        chain = FallbackChain([a], browser_provider=browser, browser_as_last_resort=False)
+
+        with pytest.raises(AllProvidersFailed):
+            chain.complete(_msgs())
+        assert browser.calls == []
+
+    def test_browser_invoked_after_all_apis_fail_with_crash(self) -> None:
+        a = StubProvider("a", [ProviderUnavailable("503")])
+        b = StubProvider("b", [QuotaExceeded("q")])
+        browser = StubProvider("browser", [BrowserDriverCrashed("oops"), "ok"])
+        chain = FallbackChain([a, b], browser_provider=browser)
+
+        with pytest.raises(AllProvidersFailed) as excinfo:
+            chain.complete(_msgs())
+        assert [pid for pid, _ in excinfo.value.failures] == ["a", "b", "browser"]
+
+    def test_circuit_breaker_opens_then_skips_then_half_open(self) -> None:
+        clock = FakeClock()
+        a = StubProvider(
+            "a",
+            [
+                ProviderUnavailable("1"),
+                ProviderUnavailable("2"),
+                ProviderUnavailable("3"),
+                "ok-after-recovery",
+            ],
+        )
+        b = StubProvider("b", ["beta-1", "beta-2", "beta-3", "beta-4"])
+        chain = FallbackChain(
+            [a, b],
+            failure_threshold=3,
+            cooldown_seconds=10,
+            clock=clock,
+        )
+
+        # Drive `a` to OPEN by failing 3x; each call falls through to `b`.
+        for _ in range(3):
+            assert chain.complete(_msgs()).startswith("beta")
+        assert chain.breaker("a").state is CircuitState.OPEN
+
+        # While OPEN, `a` is skipped without being called.
+        a_calls_before = len(a.calls)
+        assert chain.complete(_msgs()).startswith("beta")
+        assert len(a.calls) == a_calls_before  # not invoked
+
+        # After cooldown, `a` is given a half-open trial which succeeds.
+        clock.advance(10)
+        result = chain.complete(_msgs())
+        assert result == "ok-after-recovery"
+        assert chain.breaker("a").state is CircuitState.CLOSED
+
+    def test_circuit_breaker_half_open_failure_reopens(self) -> None:
+        clock = FakeClock()
+        a = StubProvider(
+            "a",
+            [ProviderUnavailable("x")] * 4,
+        )
+        b = StubProvider("b", ["beta"] * 5)
+        chain = FallbackChain([a, b], failure_threshold=2, cooldown_seconds=5, clock=clock)
+
+        # Trip the breaker.
+        chain.complete(_msgs())
+        chain.complete(_msgs())
+        assert chain.breaker("a").state is CircuitState.OPEN
+
+        # Cooldown -> half-open trial fails -> re-opens.
+        clock.advance(5)
+        chain.complete(_msgs())
+        assert chain.breaker("a").state is CircuitState.OPEN
+
+    def test_breaker_skip_recorded_in_failures_when_only_provider(self) -> None:
+        clock = FakeClock()
+        a = StubProvider("a", [ProviderUnavailable("x")])
+        chain = FallbackChain([a], failure_threshold=1, cooldown_seconds=60, clock=clock)
+
+        # First call fails and trips the breaker.
+        with pytest.raises(AllProvidersFailed):
+            chain.complete(_msgs())
+
+        # Second call: breaker is OPEN, no providers attempted, raises with a
+        # synthetic ProviderUnavailable explaining the skip.
+        with pytest.raises(AllProvidersFailed) as excinfo:
+            chain.complete(_msgs())
+        assert len(excinfo.value.failures) == 1
+        pid, exc = excinfo.value.failures[0]
+        assert pid == "a"
+        assert isinstance(exc, ProviderUnavailable)
+        assert "circuit breaker OPEN" in str(exc)
+
+    def test_kwargs_forwarded_to_provider(self) -> None:
+        a = StubProvider("a", ["ok"])
+        chain = FallbackChain([a])
+        chain.complete(_msgs(), temperature=0.7, model="x")
+        assert a.calls[0][1] == {"temperature": 0.7, "model": "x"}
+
+    def test_provider_ids_property(self) -> None:
+        chain = FallbackChain([StubProvider("a", []), StubProvider("b", [])])
+        assert chain.provider_ids == ("a", "b")
+
+    def test_chain_with_only_browser_provider_allowed(self) -> None:
+        browser = StubProvider("browser", ["only"])
+        chain = FallbackChain([], browser_provider=browser)
+        assert chain.complete(_msgs()) == "only"
+
+    def test_httpx_error_falls_through(self) -> None:
+        httpx = pytest.importorskip("httpx")
+        a = StubProvider("a", [httpx.ReadTimeout("slow")])
+        b = StubProvider("b", ["ok"])
+        chain = FallbackChain([a, b])
+        assert chain.complete(_msgs()) == "ok"


### PR DESCRIPTION
Closes #10

## Summary

Implements the **provider fallback chain with per-provider circuit breaker** described in `docs/PLAN.md` §7. The chain walks an ordered list of providers and returns the first successful response; if every API provider has been exhausted it can optionally fall through to a browser-driven provider as the last resort.

## What's in this PR

- **`orchestrator/providers/fallback.py`**
  - `FallbackChain` — ordered, configurable, with per-provider breakers.
  - `CircuitBreaker` — three states (CLOSED → OPEN → HALF_OPEN), defaults: 3 consecutive failures, 60 s cooldown.
  - `Provider` and `BrowserProvider` `typing.Protocol`s so this PR does **not** depend on #8's `LitellmRouter` or #9's Playwright driver landing first. Integration happens on rebase or in a follow-up.
  - Errors: `QuotaExceeded`, `ProviderUnavailable`, `BrowserDriverCrashed`, `AuthError`, `InvalidRequest`, `AllProvidersFailed`.
- **`orchestrator/providers/__init__.py`** — public re-exports.
- **`tests/providers/test_fallback.py`** — 23 tests; 97% coverage on the new module, 98.75% repo-wide.

## Failure classification

| Class | Examples | Behaviour |
|---|---|---|
| **Fall-through** | `QuotaExceeded`, `ProviderUnavailable` (5xx), `BrowserDriverCrashed`, `TimeoutError`, `ConnectionError`, `httpx.HTTPError` | Record the failure, trip the breaker, advance to the next provider. |
| **Terminal** | `AuthError` (401/403), `InvalidRequest` (400) | Abort the chain immediately — re-trying on a different provider would just leak the same bad credentials / payload. |

## Browser fallback

Behind the `browser_as_last_resort` flag (default `True`). The browser provider is only attempted **after** every API provider has failed. The interface is a `Protocol` stub so #9 can drop in the Playwright subprocess driver without further changes here.

## Telemetry (#54)

Every transition is emitted to the audit log via `orchestrator.observability.audit.record`:

| `action` | When |
|---|---|
| `provider_attempt` | About to call a provider. |
| `provider_success` | Provider returned a result. |
| `provider_fallthrough` | Transient failure → next provider. |
| `provider_failed_terminal` | Auth / invalid-request error → re-raise. |
| `provider_skipped` | Breaker is OPEN; provider not invoked. |
| `chain_failed` | Every provider exhausted → `AllProvidersFailed`. |

## Test coverage

```
orchestrator/providers/__init__.py    100%
orchestrator/providers/fallback.py     97%   (defensive branches only)
TOTAL repo-wide                        98.75%
```

Behavioural coverage:

- ✅ first-provider-wins
- ✅ fall-through-on-quota
- ✅ fall-through on 5xx / timeout / network / `httpx.HTTPError`
- ✅ all-fail bubbles up `AllProvidersFailed` with ordered failure list
- ✅ fail-fast on `AuthError` (second provider not invoked)
- ✅ fail-fast on `InvalidRequest`
- ✅ browser-fallback called when enabled
- ✅ browser-fallback skipped when `browser_as_last_resort=False`
- ✅ circuit breaker opens after N failures, then skips the provider
- ✅ circuit breaker half-open trial closes on success / re-opens on failure
- ✅ circuit-skip recorded as a synthetic `ProviderUnavailable` in the failure list
- ✅ kwargs forwarded verbatim to provider

## Acceptance Criteria met

- [x] `FallbackChain` wraps an ordered provider list and tries them in order.
- [x] Per-provider circuit breaker, default 3 consecutive failures, 60 s cooldown, half-open recovery.
- [x] Failure classification (rate-limit / 5xx / timeout / network → fall through; 401/403/400 → fail fast).
- [x] Browser fallback hook behind a settings-style flag.
- [x] Audit event per attempt, success, and final outcome.
- [x] Tests: first-wins, fall-through-on-quota, all-fail-bubbles-up, breaker open/half-open, fail-fast on auth, browser-fallback when enabled.
- [x] Provider interface is a `Protocol`; no concrete dependency on #8.
- [x] `ruff check` clean, coverage ≥ 95 %.

## Note on #8

PR #8 (LiteLLM router) is being implemented in parallel. The `Provider` and error types here mirror the names #8 will export. Once #8 lands the concrete `LitellmRouter` simply needs to satisfy the `Provider` protocol — no changes required to this module.
