### PR TITLE
feat(pipeline): refine step

### DIFF
--- a/orchestrator/pipeline/__init__.py
+++ b/orchestrator/pipeline/__init__.py
@@ -1,0 +1,17 @@
+"""Pipeline steps that transform user input into frontier-model calls."""
+
+from .refine import (
+    ConsolidatedBrief,
+    ModelClient,
+    RefinedPrompt,
+    RefineError,
+    refine,
+)
+
+__all__ = [
+    "ConsolidatedBrief",
+    "ModelClient",
+    "RefineError",
+    "RefinedPrompt",
+    "refine",
+]

--- a/orchestrator/pipeline/refine.py
+++ b/orchestrator/pipeline/refine.py
@@ -1,0 +1,148 @@
+"""Refine step: rewrite a consolidated brief into a frontier-model prompt.
+
+The frontier model (e.g. Claude Opus, GPT-5) is expensive, so we burn local
+compute on a resident reasoning model (default: ``qwen2.5:7b`` via Ollama)
+to produce the highest-quality prompt we can before spending a frontier call.
+
+The control flow lives here in Python; the prompt template at
+``orchestrator/prompts/refine.md`` is versioned and declarative.
+
+The step is idempotent: given the same brief and a deterministic
+``ModelClient`` (``temperature=0``), re-running ``refine`` produces a
+semantically equivalent ``RefinedPrompt``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal, Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field, ValidationError
+
+PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent.parent / "prompts" / "refine.md"
+PROMPT_TEMPLATE_VERSION = 1
+DEFAULT_MODEL = "qwen2.5:7b"
+
+ResponseFormat = Literal["markdown", "json", "code", "text"]
+ProviderHint = Literal["anthropic", "openai", "google", "local"]
+
+
+class RefineError(RuntimeError):
+    """Raised when the reasoning model fails to produce a valid RefinedPrompt.
+
+    Callers (e.g. the job runner) may downgrade to using the user message
+    verbatim as the frontier-model prompt rather than failing the whole job.
+    """
+
+
+@runtime_checkable
+class ConsolidatedBrief(Protocol):
+    """Structural type for the consolidate-step output.
+
+    The real ``ConsolidatedBrief`` Pydantic model lives in a sibling module
+    (issue #39); we depend on the *shape* only so this step can be tested
+    and shipped independently.
+    """
+
+    intent: str
+    goals: Sequence[str]
+    constraints: Sequence[str]
+    examples: Sequence[str]
+    workspace_files: Sequence[str]
+
+
+@runtime_checkable
+class ModelClient(Protocol):
+    """Minimal generate-only interface to a local reasoning model."""
+
+    def generate(self, *, model: str, prompt: str, temperature: float) -> str:
+        """Return the model's completion as a single string."""
+        ...
+
+
+class RefinedPrompt(BaseModel):
+    """High-quality prompt ready to send to a frontier model."""
+
+    system: str = Field(min_length=1)
+    user: str = Field(min_length=1)
+    response_format: ResponseFormat = "markdown"
+    max_tokens: int = Field(default=2048, ge=256, le=8192)
+    recommended_provider: ProviderHint = "anthropic"
+    template_version: int = PROMPT_TEMPLATE_VERSION
+
+
+def _brief_to_dict(brief: ConsolidatedBrief) -> dict[str, object]:
+    return {
+        "intent": brief.intent,
+        "goals": list(brief.goals),
+        "constraints": list(brief.constraints),
+        "examples": list(brief.examples),
+        "workspace_files": list(brief.workspace_files),
+    }
+
+
+def _render_template(brief: ConsolidatedBrief) -> str:
+    template = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    data = _brief_to_dict(brief)
+    examples = list(brief.examples)
+    examples_block = (
+        "\n".join(f"- {ex}" for ex in examples) if examples else "(none provided)"
+    )
+    files = list(brief.workspace_files)
+    files_block = (
+        "\n".join(f"- {f}" for f in files) if files else "(none provided)"
+    )
+    brief_json = json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False)
+    return (
+        template.replace("{brief_json}", brief_json)
+        .replace("{examples_block}", examples_block)
+        .replace("{files_block}", files_block)
+    )
+
+
+def _parse_response(raw: str) -> RefinedPrompt:
+    text = raw.strip()
+    if text.startswith("```"):
+        # strip leading ```json / ``` and trailing ```
+        text = text.split("\n", 1)[1] if "\n" in text else text
+        if text.endswith("```"):
+            text = text[: -len("```")]
+        text = text.strip()
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RefineError(f"reasoning model returned non-JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RefineError("reasoning model returned non-object JSON")
+    try:
+        return RefinedPrompt.model_validate(payload)
+    except ValidationError as exc:
+        raise RefineError(f"reasoning model output failed schema: {exc}") from exc
+
+
+def refine(
+    brief: ConsolidatedBrief,
+    *,
+    client: ModelClient,
+    model: str = DEFAULT_MODEL,
+) -> RefinedPrompt:
+    """Run the refine pipeline step.
+
+    Calls the reasoning ``client`` with the rendered prompt template and
+    parses the response into a ``RefinedPrompt``. Retries once on
+    schema-validation failure; a second failure raises ``RefineError``.
+
+    Idempotent given a deterministic client (``temperature=0``).
+    """
+    prompt = _render_template(brief)
+    last_error: RefineError | None = None
+    for _ in range(2):
+        raw = client.generate(model=model, prompt=prompt, temperature=0.0)
+        try:
+            return _parse_response(raw)
+        except RefineError as exc:
+            last_error = exc
+    assert last_error is not None
+    raise last_error

--- a/orchestrator/pipeline/refine.py
+++ b/orchestrator/pipeline/refine.py
@@ -87,13 +87,9 @@ def _render_template(brief: ConsolidatedBrief) -> str:
     template = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
     data = _brief_to_dict(brief)
     examples = list(brief.examples)
-    examples_block = (
-        "\n".join(f"- {ex}" for ex in examples) if examples else "(none provided)"
-    )
+    examples_block = "\n".join(f"- {ex}" for ex in examples) if examples else "(none provided)"
     files = list(brief.workspace_files)
-    files_block = (
-        "\n".join(f"- {f}" for f in files) if files else "(none provided)"
-    )
+    files_block = "\n".join(f"- {f}" for f in files) if files else "(none provided)"
     brief_json = json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False)
     return (
         template.replace("{brief_json}", brief_json)

--- a/orchestrator/prompts/refine.md
+++ b/orchestrator/prompts/refine.md
@@ -1,0 +1,56 @@
+<!--
+version: 1
+purpose: Reasoning-model prompt for refining a ConsolidatedBrief into a high-quality
+         prompt suitable for a large frontier AI model.
+-->
+
+# Role
+
+You are a senior prompt engineer. Your job is to take a *consolidated brief*
+describing what a user wants and rewrite it as a single, high-quality prompt
+that will be sent to a large, expensive frontier AI model. We burn local
+compute now so every frontier-model call counts.
+
+# Success criteria
+
+A great refined prompt:
+
+1. Restates the user's intent in one short paragraph at the top.
+2. Lists the relevant workspace files / context blocks the model should read.
+3. States explicit constraints and acceptance criteria the answer must meet.
+4. Defines the required output format (markdown, JSON schema, code, etc.).
+5. Includes 1–2 illustrative examples lifted verbatim from the brief when
+   present. Do not invent examples.
+6. Is self-contained: the frontier model never needs to ask follow-up
+   questions to act on it.
+
+# Output format
+
+Return **only** a single JSON object — no prose, no markdown fences — with
+exactly these keys:
+
+```
+{
+  "system": "<system message that sets role + global rules>",
+  "user": "<user message containing intent, context, constraints, examples>",
+  "response_format": "markdown" | "json" | "code" | "text",
+  "max_tokens": <integer between 256 and 8192>,
+  "recommended_provider": "anthropic" | "openai" | "google" | "local"
+}
+```
+
+# Brief
+
+```json
+{brief_json}
+```
+
+# Examples from the brief
+
+{examples_block}
+
+# Workspace files referenced
+
+{files_block}
+
+Now produce the JSON object.

--- a/tests/pipeline/test_refine.py
+++ b/tests/pipeline/test_refine.py
@@ -25,15 +25,9 @@ from orchestrator.pipeline.refine import (
 @dataclass
 class FakeBrief:
     intent: str = "Refactor the auth module to use JWT."
-    goals: list[str] = field(
-        default_factory=lambda: ["Replace session cookies", "Keep API stable"]
-    )
-    constraints: list[str] = field(
-        default_factory=lambda: ["No new dependencies", "Python 3.11+"]
-    )
-    examples: list[str] = field(
-        default_factory=lambda: ["login() returns {token, expires_at}"]
-    )
+    goals: list[str] = field(default_factory=lambda: ["Replace session cookies", "Keep API stable"])
+    constraints: list[str] = field(default_factory=lambda: ["No new dependencies", "Python 3.11+"])
+    examples: list[str] = field(default_factory=lambda: ["login() returns {token, expires_at}"])
     workspace_files: list[str] = field(
         default_factory=lambda: ["src/auth.py", "tests/test_auth.py"]
     )
@@ -47,9 +41,7 @@ class ScriptedClient:
         self.calls: list[dict[str, object]] = []
 
     def generate(self, *, model: str, prompt: str, temperature: float) -> str:
-        self.calls.append(
-            {"model": model, "prompt": prompt, "temperature": temperature}
-        )
+        self.calls.append({"model": model, "prompt": prompt, "temperature": temperature})
         if not self.responses:
             raise AssertionError("no more scripted responses")
         return self.responses.pop(0)

--- a/tests/pipeline/test_refine.py
+++ b/tests/pipeline/test_refine.py
@@ -1,0 +1,186 @@
+"""Tests for the refine pipeline step."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+import pytest
+
+from orchestrator.pipeline import (
+    ConsolidatedBrief,
+    ModelClient,
+    RefinedPrompt,
+    RefineError,
+    refine,
+)
+from orchestrator.pipeline.refine import (
+    DEFAULT_MODEL,
+    PROMPT_TEMPLATE_VERSION,
+    _parse_response,
+    _render_template,
+)
+
+
+@dataclass
+class FakeBrief:
+    intent: str = "Refactor the auth module to use JWT."
+    goals: list[str] = field(
+        default_factory=lambda: ["Replace session cookies", "Keep API stable"]
+    )
+    constraints: list[str] = field(
+        default_factory=lambda: ["No new dependencies", "Python 3.11+"]
+    )
+    examples: list[str] = field(
+        default_factory=lambda: ["login() returns {token, expires_at}"]
+    )
+    workspace_files: list[str] = field(
+        default_factory=lambda: ["src/auth.py", "tests/test_auth.py"]
+    )
+
+
+class ScriptedClient:
+    """ModelClient stub that returns a queued sequence of responses."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def generate(self, *, model: str, prompt: str, temperature: float) -> str:
+        self.calls.append(
+            {"model": model, "prompt": prompt, "temperature": temperature}
+        )
+        if not self.responses:
+            raise AssertionError("no more scripted responses")
+        return self.responses.pop(0)
+
+
+VALID_PAYLOAD = {
+    "system": "You are a senior staff engineer.",
+    "user": "Refactor auth to JWT, keep API stable, no new deps.",
+    "response_format": "code",
+    "max_tokens": 4096,
+    "recommended_provider": "anthropic",
+}
+
+
+def _json(payload: dict[str, object]) -> str:
+    return json.dumps(payload)
+
+
+def test_protocols_runtime_checkable() -> None:
+    assert isinstance(FakeBrief(), ConsolidatedBrief)
+    assert isinstance(ScriptedClient([]), ModelClient)
+
+
+def test_render_template_includes_brief_fields() -> None:
+    brief = FakeBrief()
+    rendered = _render_template(brief)
+    assert "Refactor the auth module" in rendered
+    assert "src/auth.py" in rendered
+    assert "login() returns" in rendered
+    # JSON dump should be present
+    assert '"intent"' in rendered
+
+
+def test_render_template_handles_empty_examples_and_files() -> None:
+    brief = FakeBrief(examples=[], workspace_files=[])
+    rendered = _render_template(brief)
+    assert "(none provided)" in rendered
+
+
+def test_refine_happy_path_returns_refined_prompt() -> None:
+    client = ScriptedClient([_json(VALID_PAYLOAD)])
+    brief = FakeBrief()
+
+    result = refine(brief, client=client)
+
+    assert isinstance(result, RefinedPrompt)
+    assert result.system == VALID_PAYLOAD["system"]
+    assert result.user == VALID_PAYLOAD["user"]
+    assert result.response_format == "code"
+    assert result.max_tokens == 4096
+    assert result.recommended_provider == "anthropic"
+    assert result.template_version == PROMPT_TEMPLATE_VERSION
+    assert len(client.calls) == 1
+    assert client.calls[0]["model"] == DEFAULT_MODEL
+    assert client.calls[0]["temperature"] == 0.0
+
+
+def test_refine_strips_markdown_code_fences() -> None:
+    fenced = "```json\n" + _json(VALID_PAYLOAD) + "\n```"
+    client = ScriptedClient([fenced])
+    result = refine(FakeBrief(), client=client)
+    assert result.system == VALID_PAYLOAD["system"]
+
+
+def test_refine_strips_plain_code_fences() -> None:
+    fenced = "```\n" + _json(VALID_PAYLOAD) + "\n```"
+    client = ScriptedClient([fenced])
+    result = refine(FakeBrief(), client=client)
+    assert result.user == VALID_PAYLOAD["user"]
+
+
+def test_refine_retries_once_on_schema_violation() -> None:
+    bad = _json({"system": "ok"})  # missing user
+    client = ScriptedClient([bad, _json(VALID_PAYLOAD)])
+
+    result = refine(FakeBrief(), client=client)
+
+    assert result.system == VALID_PAYLOAD["system"]
+    assert len(client.calls) == 2
+
+
+def test_refine_retries_once_on_invalid_json() -> None:
+    client = ScriptedClient(["not json at all", _json(VALID_PAYLOAD)])
+    result = refine(FakeBrief(), client=client)
+    assert isinstance(result, RefinedPrompt)
+    assert len(client.calls) == 2
+
+
+def test_refine_raises_after_two_failures() -> None:
+    client = ScriptedClient(["nope", "still nope"])
+    with pytest.raises(RefineError):
+        refine(FakeBrief(), client=client)
+    assert len(client.calls) == 2
+
+
+def test_refine_raises_on_non_object_json() -> None:
+    client = ScriptedClient(["[1, 2, 3]", "[4, 5]"])
+    with pytest.raises(RefineError, match="non-object"):
+        refine(FakeBrief(), client=client)
+
+
+def test_refine_passes_custom_model_name() -> None:
+    client = ScriptedClient([_json(VALID_PAYLOAD)])
+    refine(FakeBrief(), client=client, model="llama3:8b")
+    assert client.calls[0]["model"] == "llama3:8b"
+
+
+def test_refine_is_idempotent_for_deterministic_client() -> None:
+    payload = _json(VALID_PAYLOAD)
+    c1 = ScriptedClient([payload])
+    c2 = ScriptedClient([payload])
+    r1 = refine(FakeBrief(), client=c1)
+    r2 = refine(FakeBrief(), client=c2)
+    assert r1.model_dump() == r2.model_dump()
+
+
+def test_parse_response_rejects_bad_max_tokens() -> None:
+    payload = dict(VALID_PAYLOAD, max_tokens=10)
+    with pytest.raises(RefineError):
+        _parse_response(_json(payload))
+
+
+def test_parse_response_rejects_unknown_provider() -> None:
+    payload = dict(VALID_PAYLOAD, recommended_provider="acme-ai")
+    with pytest.raises(RefineError):
+        _parse_response(_json(payload))
+
+
+def test_refined_prompt_defaults() -> None:
+    rp = RefinedPrompt(system="s", user="u")
+    assert rp.response_format == "markdown"
+    assert rp.max_tokens == 2048
+    assert rp.recommended_provider == "anthropic"
+    assert rp.template_version == PROMPT_TEMPLATE_VERSION


### PR DESCRIPTION
Closes #40

Acceptance Criteria met.

## Summary

Implements the `refine` pipeline step that takes a `ConsolidatedBrief`-shaped input and uses a local reasoning model (default `qwen2.5:7b` via an injected `ModelClient` Protocol) to produce a high-quality prompt for a frontier AI model.

## Changes

- `orchestrator/pipeline/refine.py`: `ConsolidatedBrief` and `ModelClient` Protocols, `RefinedPrompt` Pydantic model (system, user, response_format, max_tokens, recommended_provider, template_version), `refine()` with one-shot retry and `RefineError`.
- `orchestrator/prompts/refine.md`: versioned (v1) declarative template with role framing, success criteria, output-format constraints, and examples lifted from the brief.
- `orchestrator/pipeline/__init__.py`: re-exports.
- `tests/pipeline/test_refine.py`: happy path, schema-violation retry, JSON-decode retry, retry exhaustion, idempotence, defaults, validation edges.

## Verification

- `ruff check .` clean
- `pytest` 290 passed, 1 skipped
- pipeline package coverage 99% (project gate >= 95%)
- Idempotent: deterministic `ModelClient` (temperature=0) yields equivalent `RefinedPrompt` across runs
- No live LLM calls in tests