### PR TITLE
feat(pipeline): plan step

### DIFF
--- a/orchestrator/pipeline/__init__.py
+++ b/orchestrator/pipeline/__init__.py
@@ -13,6 +13,13 @@ from .execute import (
     execute,
 )
 from .execute import ExecutableStep as ExecutableStep
+from .plan import (
+    BigModelRouter,
+    EventHandler,
+    PlanError,
+    PlanStepKind,
+    plan,
+)
 from .refine import (
     ConsolidatedBrief,
     ModelClient,
@@ -30,15 +37,19 @@ from .verify import (
 )
 
 __all__ = [
+    "BigModelRouter",
     "CoderClient",
     "ConsolidatedBrief",
+    "EventHandler",
     "ExecutableStep",
     "ExecuteError",
     "IterationCapError",
     "ModelClient",
     "OllamaClient",
     "Plan",
+    "PlanError",
     "PlanStep",
+    "PlanStepKind",
     "RefineError",
     "RefinedPrompt",
     "Scheduler",
@@ -48,6 +59,7 @@ __all__ = [
     "ToolRegistry",
     "VerifyDecision",
     "execute",
+    "plan",
     "refine",
     "verify",
 ]

--- a/orchestrator/pipeline/plan.py
+++ b/orchestrator/pipeline/plan.py
@@ -1,0 +1,262 @@
+"""Pipeline ``plan`` step.
+
+Invokes the *big* AI model (via the :class:`BigModelRouter` protocol) with a
+:class:`RefinedPrompt` and parses the response into a JSON-schema-validated
+:class:`Plan`. On validation failure the planner retries **once** with a
+self-correcting follow-up message; a second failure raises :class:`PlanError`.
+
+The step writes a SQLite checkpoint (``step='plan'``) before returning and,
+when streaming is enabled, emits per-step events for UI consumption.
+
+Only this module, ``orchestrator/prompts/plan.md`` and the package
+``__init__`` are touched as part of this change.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import warnings
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any, Literal, Protocol, runtime_checkable
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from .refine import RefinedPrompt
+
+logger = structlog.get_logger("orchestrator.pipeline.plan")
+
+_PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "plan.md"
+
+PlanStepKind = Literal["shell", "code", "web", "verify"]
+
+
+class PlanStep(BaseModel):
+    """A single step in a multi-step plan."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(..., min_length=1)
+    kind: PlanStepKind
+    goal: str = Field(..., min_length=1)
+    expected_output_shape: str = Field(..., min_length=1)
+    required_tools: list[str] = Field(default_factory=list)
+    estimated_tokens: int = Field(..., ge=0)
+    fallback_strategy: str = Field(..., min_length=1)
+
+
+class Plan(BaseModel):
+    """A validated multi-step plan with a single root summary."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    summary: str = Field(..., min_length=1)
+    steps: list[PlanStep] = Field(..., min_length=1)
+
+
+class PlanError(RuntimeError):
+    """Raised when the planner cannot produce a valid plan after one retry.
+
+    The last raw model output is attached as :attr:`last_raw_output` for
+    debugging by upstream callers (job runner, CLI, etc.).
+    """
+
+    def __init__(self, message: str, *, last_raw_output: str) -> None:
+        super().__init__(message)
+        self.last_raw_output = last_raw_output
+
+
+@runtime_checkable
+class BigModelRouter(Protocol):
+    """Protocol for the *big* AI router used by the plan step.
+
+    Implementations are provider-agnostic (OpenAI, Anthropic, local llama.cpp,
+    ...). Only the ``complete`` method is required. Tests provide a fake.
+    """
+
+    def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        response_format: dict[str, Any] | None = ...,
+    ) -> str:  # pragma: no cover - protocol definition
+        ...
+
+
+EventHandler = Callable[[dict[str, Any]], None]
+
+
+def _load_system_prompt() -> str:
+    return _PROMPT_PATH.read_text(encoding="utf-8")
+
+
+def _build_messages(refined: RefinedPrompt) -> list[dict[str, str]]:
+    schema = json.dumps(Plan.model_json_schema(), indent=2)
+    system = (
+        f"{_load_system_prompt()}\n\n"
+        f"## Upstream system guidance\n\n{refined.system}\n\n"
+        "## JSON Schema (authoritative)\n\n"
+        f"```json\n{schema}\n```\n"
+    )
+    user_payload = {"prompt": refined.user}
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": json.dumps(user_payload)},
+    ]
+
+
+def _parse_plan(raw: str) -> Plan:
+    """Parse and validate a raw model response into a :class:`Plan`."""
+    data = json.loads(raw)
+    return Plan.model_validate(data)
+
+
+def _dedupe_step_ids(plan: Plan) -> Plan:
+    """Auto-suffix duplicate step IDs and emit a warning.
+
+    Mirrors the AC: duplicates become ``<id>``, ``<id>_2``, ``<id>_3`` ...
+    """
+    seen: dict[str, int] = {}
+    new_steps: list[PlanStep] = []
+    rewrote = False
+    for step in plan.steps:
+        base = step.id
+        count = seen.get(base, 0) + 1
+        seen[base] = count
+        if count == 1:
+            new_steps.append(step)
+            continue
+        rewrote = True
+        new_id = f"{base}_{count}"
+        warnings.warn(
+            f"plan: duplicate step id {base!r} auto-suffixed to {new_id!r}",
+            stacklevel=2,
+        )
+        logger.warning(
+            "plan.duplicate_step_id",
+            original_id=base,
+            new_id=new_id,
+        )
+        new_steps.append(step.model_copy(update={"id": new_id}))
+    if not rewrote:
+        return plan
+    return plan.model_copy(update={"steps": new_steps})
+
+
+def _checkpoint(db_path: str | Path, refined: RefinedPrompt, plan: Plan) -> None:
+    """Persist the plan to SQLite under ``step='plan'``."""
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS checkpoints (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                step TEXT NOT NULL,
+                refined_prompt TEXT NOT NULL,
+                plan_json TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO checkpoints (step, refined_prompt, plan_json) VALUES (?, ?, ?)",
+            ("plan", refined.model_dump_json(), plan.model_dump_json()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _emit_stream(plan: Plan, handler: EventHandler) -> None:
+    handler({"event": "plan.started", "summary": plan.summary, "step_count": len(plan.steps)})
+    for index, step in enumerate(plan.steps):
+        handler({"event": "plan.step", "index": index, "step": step.model_dump()})
+    handler({"event": "plan.completed", "step_count": len(plan.steps)})
+
+
+def plan(
+    refined: RefinedPrompt,
+    *,
+    big_ai: BigModelRouter,
+    checkpoint_db: str | Path | None = None,
+    stream: bool = False,
+    event_handler: EventHandler | None = None,
+) -> Plan:
+    """Produce a validated :class:`Plan` from a :class:`RefinedPrompt`.
+
+    Parameters
+    ----------
+    refined:
+        Output of the ``refine`` step.
+    big_ai:
+        A :class:`BigModelRouter` implementation. Tests pass a fake.
+    checkpoint_db:
+        Optional path to a SQLite database. When given, the validated plan is
+        persisted under ``step='plan'`` before returning.
+    stream:
+        When ``True``, emits per-step events via ``event_handler``.
+    event_handler:
+        Required when ``stream=True``. Called once with ``plan.started``,
+        once per step with ``plan.step``, and once with ``plan.completed``.
+    """
+    if stream and event_handler is None:
+        raise ValueError("event_handler is required when stream=True")
+
+    messages = _build_messages(refined)
+    response_format = {"type": "json_object"}
+
+    raw = big_ai.complete(messages, response_format=response_format)
+    try:
+        parsed = _parse_plan(raw)
+    except (json.JSONDecodeError, ValidationError) as exc:
+        errors: Iterable[Any]
+        if isinstance(exc, ValidationError):
+            errors = exc.errors()
+        else:
+            errors = [{"type": "json_decode", "msg": str(exc)}]
+        logger.warning("plan.validation_failed", errors=list(errors))
+        correction = (
+            "Your previous output failed validation: "
+            f"{json.dumps(list(errors), default=str)}. "
+            "Return ONLY a JSON object that matches the embedded schema. "
+            "No prose, no markdown fences."
+        )
+        retry_messages = [
+            *messages,
+            {"role": "assistant", "content": raw},
+            {"role": "user", "content": correction},
+        ]
+        retry_raw = big_ai.complete(retry_messages, response_format=response_format)
+        try:
+            parsed = _parse_plan(retry_raw)
+        except (json.JSONDecodeError, ValidationError) as retry_exc:
+            logger.error("plan.retry_failed", error=str(retry_exc))
+            raise PlanError(
+                f"plan validation failed after retry: {retry_exc}",
+                last_raw_output=retry_raw,
+            ) from retry_exc
+
+    parsed = _dedupe_step_ids(parsed)
+
+    if checkpoint_db is not None:
+        _checkpoint(checkpoint_db, refined, parsed)
+
+    if stream and event_handler is not None:
+        _emit_stream(parsed, event_handler)
+
+    return parsed
+
+
+__all__ = [
+    "BigModelRouter",
+    "EventHandler",
+    "Plan",
+    "PlanError",
+    "PlanStep",
+    "PlanStepKind",
+    "RefinedPrompt",
+    "plan",
+]

--- a/orchestrator/prompts/plan.md
+++ b/orchestrator/prompts/plan.md
@@ -1,0 +1,34 @@
+# Plan step — system prompt
+
+You are the **planner** for a local-first agent orchestrator. You receive a
+refined user prompt and must return a structured, multi-step execution plan.
+
+## Output contract
+
+Return **only** a JSON object that conforms to the schema embedded below. Do
+not wrap it in markdown fences. Do not include any prose outside of the JSON.
+
+The object MUST contain:
+
+- `summary` — a single short paragraph (≤ 2 sentences) explaining the overall
+  approach. This is the "root rationale" surfaced to the user.
+- `steps` — an ordered list of plan steps. Each step MUST contain:
+  - `id` — a stable, kebab-case identifier unique within the plan.
+  - `kind` — one of `shell`, `code`, `web`, `verify`.
+  - `goal` — a concise statement of what the step accomplishes.
+  - `expected_output_shape` — a description of the artifact/result the step
+    must produce (e.g. `"JSON list of file paths"`, `"unit-test pass/fail"`).
+  - `required_tools` — list of tool names the step depends on (may be empty).
+  - `estimated_tokens` — rough integer estimate of LLM tokens this step will
+    consume downstream (0 if no LLM call is expected).
+  - `fallback_strategy` — what to do if the step fails (e.g. `"retry once
+    with stricter prompt"`, `"skip and continue"`, `"abort plan"`).
+
+## Rules
+
+1. Prefer the smallest number of steps that fully addresses the prompt.
+2. Steps must be independently checkpointable — no implicit shared state.
+3. Always include at least one `verify` step at the end.
+4. If the prompt is ambiguous, encode the assumption in `summary` rather than
+   asking the user a question.
+5. Return ONLY the JSON object. No commentary.

--- a/tests/pipeline/test_plan.py
+++ b/tests/pipeline/test_plan.py
@@ -1,0 +1,187 @@
+"""Tests for the pipeline plan step."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.pipeline import (
+    BigModelRouter,
+    PlanError,
+    RefinedPrompt,
+    plan,
+)
+from orchestrator.pipeline.plan import Plan, PlanStep, _load_system_prompt
+
+
+def _valid_plan_payload(*, ids: list[str] | None = None) -> dict[str, Any]:
+    ids = ids or ["discover", "implement", "verify"]
+    kinds = ["shell", "code", "verify"]
+    return {
+        "summary": "Discover, implement, verify.",
+        "steps": [
+            {
+                "id": step_id,
+                "kind": kinds[i % len(kinds)],
+                "goal": f"goal-{step_id}",
+                "expected_output_shape": "string",
+                "required_tools": ["fs"],
+                "estimated_tokens": 100,
+                "fallback_strategy": "retry once",
+            }
+            for i, step_id in enumerate(ids)
+        ],
+    }
+
+
+class FakeBigAI:
+    """Configurable fake :class:`BigModelRouter`."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+        self.calls: list[list[dict[str, str]]] = []
+        self.response_formats: list[dict[str, Any] | None] = []
+
+    def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        response_format: dict[str, Any] | None = None,
+    ) -> str:
+        self.calls.append(messages)
+        self.response_formats.append(response_format)
+        if not self._responses:
+            raise AssertionError("FakeBigAI ran out of canned responses")
+        return self._responses.pop(0)
+
+
+@pytest.fixture
+def refined() -> RefinedPrompt:
+    return RefinedPrompt(
+        system="You are a planning assistant for project demo.",
+        user="ship feature x",
+    )
+
+
+def test_protocol_runtime_check() -> None:
+    fake = FakeBigAI([json.dumps(_valid_plan_payload())])
+    assert isinstance(fake, BigModelRouter)
+
+
+def test_plan_returns_validated_plan(refined: RefinedPrompt) -> None:
+    fake = FakeBigAI([json.dumps(_valid_plan_payload())])
+    result = plan(refined, big_ai=fake)
+    assert isinstance(result, Plan)
+    assert result.summary == "Discover, implement, verify."
+    assert [s.id for s in result.steps] == ["discover", "implement", "verify"]
+    assert isinstance(result.steps[0], PlanStep)
+    # Single call: no retry path was needed.
+    assert len(fake.calls) == 1
+    assert fake.response_formats == [{"type": "json_object"}]
+
+
+def test_plan_embeds_schema_in_system_prompt(refined: RefinedPrompt) -> None:
+    fake = FakeBigAI([json.dumps(_valid_plan_payload())])
+    plan(refined, big_ai=fake)
+    system_message = fake.calls[0][0]
+    assert system_message["role"] == "system"
+    assert "JSON Schema" in system_message["content"]
+    assert "expected_output_shape" in system_message["content"]
+    assert _load_system_prompt().splitlines()[0] in system_message["content"]
+
+
+def test_model_json_schema_exported() -> None:
+    schema = Plan.model_json_schema()
+    assert schema["type"] == "object"
+    assert "steps" in schema["properties"]
+
+
+def test_retry_succeeds_on_validation_error(refined: RefinedPrompt) -> None:
+    bad = json.dumps({"summary": "x", "steps": []})  # empty steps -> validation error
+    good = json.dumps(_valid_plan_payload())
+    fake = FakeBigAI([bad, good])
+    result = plan(refined, big_ai=fake)
+    assert len(result.steps) == 3
+    assert len(fake.calls) == 2
+    correction = fake.calls[1][-1]
+    assert correction["role"] == "user"
+    assert "failed validation" in correction["content"]
+
+
+def test_retry_succeeds_on_json_parse_error(refined: RefinedPrompt) -> None:
+    bad = "not json at all {"
+    good = json.dumps(_valid_plan_payload())
+    fake = FakeBigAI([bad, good])
+    result = plan(refined, big_ai=fake)
+    assert len(result.steps) == 3
+    assert len(fake.calls) == 2
+
+
+def test_retry_exhaustion_raises_plan_error(refined: RefinedPrompt) -> None:
+    bad1 = "definitely not json"
+    bad2 = json.dumps({"summary": "still bad", "steps": []})
+    fake = FakeBigAI([bad1, bad2])
+    with pytest.raises(PlanError) as exc_info:
+        plan(refined, big_ai=fake)
+    assert exc_info.value.last_raw_output == bad2
+    assert "validation failed after retry" in str(exc_info.value)
+
+
+def test_duplicate_ids_are_auto_suffixed(refined: RefinedPrompt) -> None:
+    payload = _valid_plan_payload(ids=["s1", "s1", "s1"])
+    fake = FakeBigAI([json.dumps(payload)])
+    with pytest.warns(UserWarning, match="duplicate step id"):
+        result = plan(refined, big_ai=fake)
+    assert [s.id for s in result.steps] == ["s1", "s1_2", "s1_3"]
+
+
+def test_no_dedupe_when_ids_unique(refined: RefinedPrompt) -> None:
+    fake = FakeBigAI([json.dumps(_valid_plan_payload())])
+    result = plan(refined, big_ai=fake)
+    assert [s.id for s in result.steps] == ["discover", "implement", "verify"]
+
+
+def test_checkpoint_writes_to_sqlite(refined: RefinedPrompt, tmp_path: Path) -> None:
+    db = tmp_path / "nested" / "ckpt.db"
+    fake = FakeBigAI([json.dumps(_valid_plan_payload())])
+    result = plan(refined, big_ai=fake, checkpoint_db=db)
+    assert db.exists()
+    conn = sqlite3.connect(str(db))
+    try:
+        rows = conn.execute(
+            "SELECT step, refined_prompt, plan_json FROM checkpoints"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    step, refined_json, plan_json = rows[0]
+    assert step == "plan"
+    assert json.loads(refined_json)["user"] == "ship feature x"
+    assert json.loads(plan_json) == json.loads(result.model_dump_json())
+
+
+def test_streaming_emits_step_events(refined: RefinedPrompt) -> None:
+    fake = FakeBigAI([json.dumps(_valid_plan_payload())])
+    events: list[dict[str, Any]] = []
+    plan(refined, big_ai=fake, stream=True, event_handler=events.append)
+    kinds = [e["event"] for e in events]
+    assert kinds == ["plan.started", "plan.step", "plan.step", "plan.step", "plan.completed"]
+    assert events[0]["step_count"] == 3
+    assert events[1]["step"]["id"] == "discover"
+    assert events[-1]["step_count"] == 3
+
+
+def test_streaming_requires_handler(refined: RefinedPrompt) -> None:
+    fake = FakeBigAI([json.dumps(_valid_plan_payload())])
+    with pytest.raises(ValueError, match="event_handler is required"):
+        plan(refined, big_ai=fake, stream=True)
+
+
+def test_plan_error_attaches_raw_output() -> None:
+    err = PlanError("boom", last_raw_output="<garbage>")
+    assert err.last_raw_output == "<garbage>"
+    assert "boom" in str(err)

--- a/tests/pipeline/test_plan.py
+++ b/tests/pipeline/test_plan.py
@@ -152,9 +152,7 @@ def test_checkpoint_writes_to_sqlite(refined: RefinedPrompt, tmp_path: Path) -> 
     assert db.exists()
     conn = sqlite3.connect(str(db))
     try:
-        rows = conn.execute(
-            "SELECT step, refined_prompt, plan_json FROM checkpoints"
-        ).fetchall()
+        rows = conn.execute("SELECT step, refined_prompt, plan_json FROM checkpoints").fetchall()
     finally:
         conn.close()
     assert len(rows) == 1


### PR DESCRIPTION
Closes #41

## Summary
Implements the pipeline `plan` step: calls the big AI router (`BigModelRouter` Protocol) with a `RefinedPrompt` and returns a JSON-schema-validated multi-step `Plan`.

## Acceptance Criteria met
- `Plan` / `PlanStep` Pydantic models with `summary` + `steps` (id, kind, goal, expected_output_shape, required_tools, estimated_tokens, fallback_strategy).
- JSON Schema exported via `Plan.model_json_schema()` and embedded in the system prompt.
- `plan(refined, *, big_ai, checkpoint_db=None, stream=False, event_handler=None) -> Plan` in `orchestrator/pipeline/plan.py`.
- One self-correcting retry on `json.JSONDecodeError` / `pydantic.ValidationError` with the validation errors fed back verbatim.
- Second failure raises `PlanError` with `last_raw_output` attached.
- Duplicate step IDs auto-suffixed (`id_2`, `id_3`...) with a warning + structured log.
- SQLite checkpoint (`step='plan'`) written before returning when `checkpoint_db` is given.
- Optional streaming emits `plan.started` / `plan.step` / `plan.completed` events.
- `BigModelRouter` is a runtime-checkable Protocol; all tests use a fake (no real API calls).

## Scope
Only `orchestrator/pipeline/plan.py`, `orchestrator/pipeline/__init__.py`, `orchestrator/prompts/plan.md`, `tests/pipeline/test_plan.py` (+ `tests/pipeline/__init__.py`) touched.

## Verification
- `ruff check .` — clean.
- `pytest tests/pipeline` — 13 passed, 100% coverage on new module.
- Full suite — 288 passed, 1 skipped, total coverage 98.87% (gate 95%).
- Commit GPG-signed with key `9C8C0949390E528F`.
