### PR TITLE
ops(compose): docker-compose with Ollama + model pre-pull

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# Copy to `.env` and fill in. Compose auto-loads `.env` from the project
+# root. Every variable below is consumed by the orchestrator and/or
+# Ollama services in `compose.yaml`.
+#
+#   cp .env.example .env
+#   ${EDITOR:-vi} .env
+#   docker compose up -d
+
+# --- orchestrator -------------------------------------------------------
+
+# Logging verbosity for the orchestrator. One of:
+#   DEBUG | INFO | WARNING | ERROR | CRITICAL
+ORCH_LOG_LEVEL=INFO
+
+# Hard ceiling on resident memory (MiB) before the orchestrator starts
+# shedding background work. Leave blank to let it auto-detect from cgroup
+# limits.
+ORCH_RAM_HARD_CAP_MB=
+
+# Host port to bind for the orchestrator HTTP API. Container always
+# listens on 8000 internally.
+ORCH_HOST_PORT=8000
+
+# --- inference backend (Ollama) -----------------------------------------
+
+# Whitespace-separated list of model tags the one-shot `ollama-init`
+# service will pull on `docker compose --profile init up ollama-init`.
+# Override to add/remove models without editing compose.yaml.
+OLLAMA_MODELS=qwen2.5:7b qwen2.5-coder:7b qwen2.5:1.5b
+
+# How long Ollama keeps a model resident in VRAM/RAM after the last
+# request. Accepts Go duration strings (e.g. `30s`, `5m`, `1h`).
+OLLAMA_KEEP_ALIVE=5m
+
+# --- free-tier hosted-model API keys ------------------------------------
+# All optional. Leave blank to disable that provider in the orchestrator's
+# routing tier. Never commit a populated `.env` — `.gitignore` covers it.
+
+GEMINI_API_KEY=
+GROQ_API_KEY=
+OPENROUTER_API_KEY=

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: help install lint format test cov precommit clean serve docker-build docker-run
+.PHONY: help install lint format test cov precommit clean serve docker-build docker-run \
+        compose-up compose-down compose-init compose-logs compose-pull
 
 .DEFAULT_GOAL := help
 
@@ -44,3 +45,20 @@ docker-run: ## Run the slim image with sensible local defaults
 		-v $(PWD)/config:/etc/orchestrator:ro \
 		-v orchestrator-data:/var/lib/orchestrator \
 		$(IMAGE)
+
+# --- docker compose -----------------------------------------------------
+
+compose-up: ## Bring up the compose stack (ollama + orchestrator)
+	docker compose up -d
+
+compose-down: ## Stop the compose stack (preserves named volumes)
+	docker compose down
+
+compose-init: ## One-shot: pull the default model set into the ollama volume
+	docker compose --profile init up --exit-code-from ollama-init ollama-init
+
+compose-logs: ## Tail logs from the running compose stack
+	docker compose logs -f --tail=200
+
+compose-pull: ## Pull the latest base images referenced by compose.yaml
+	docker compose pull

--- a/compose.browser.yaml
+++ b/compose.browser.yaml
@@ -1,0 +1,17 @@
+# Overlay: swap the orchestrator image to the browser-fallback variant
+# (Playwright + Chromium baked in, ~600 MB). Apply on top of compose.yaml:
+#
+#   docker compose -f compose.yaml -f compose.browser.yaml up -d
+#
+# Only intended for environments that need the optional browser-fallback
+# search path (#9). Prefer the slim image otherwise.
+
+services:
+  orchestrator:
+    build:
+      context: .
+      dockerfile: Dockerfile.browser
+      target: runtime
+    image: orchestrator:browser
+    environment:
+      ORCH_BROWSER_FALLBACK: "1"

--- a/compose.init.yaml
+++ b/compose.init.yaml
@@ -1,0 +1,17 @@
+# Overlay: first-time model pre-pull. The `ollama-init` service is also
+# defined in compose.yaml under the `init` profile; this overlay exists
+# so operators can compose the stack with `-f compose.init.yaml` and
+# tweak the model list locally without editing the main file.
+#
+# Usage:
+#   docker compose -f compose.yaml -f compose.init.yaml --profile init up ollama-init
+#
+# Customize the model set via the OLLAMA_MODELS env var (whitespace-
+# separated tags). Defaults below mirror the orchestrator's recommended
+# stack.
+
+services:
+  ollama-init:
+    profiles: ["init"]
+    environment:
+      OLLAMA_MODELS: ${OLLAMA_MODELS:-qwen2.5:7b qwen2.5-coder:7b qwen2.5:1.5b}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,97 @@
+# Compose stack for the orchestrator + a local Ollama backend.
+#
+# Default usage (cold start, assumes models already pulled):
+#   docker compose up -d
+#
+# First-time / model pre-pull (one-shot):
+#   docker compose --profile init up ollama-init
+#   # or via the dedicated overlay:
+#   docker compose -f compose.yaml -f compose.init.yaml --profile init up
+#
+# Browser-fallback variant:
+#   docker compose -f compose.yaml -f compose.browser.yaml up -d
+#
+# `docker compose down` preserves named volumes; `docker compose down -v`
+# removes them (i.e. wipes the local model cache and orchestrator data).
+
+name: orchestrator
+
+# --- inference backend --------------------------------------------------
+services:
+  ollama:
+    image: ollama/ollama:latest
+    # Internal-only by default — the orchestrator service reaches it over
+    # the compose network at `http://ollama:11434`. To expose Ollama on
+    # the host, copy `docker-compose.override.yml.example` and uncomment
+    # the `ports:` block there.
+    expose:
+      - "11434"
+    volumes:
+      - ollama-models:/root/.ollama
+    environment:
+      OLLAMA_HOST: 0.0.0.0:11434
+      OLLAMA_KEEP_ALIVE: ${OLLAMA_KEEP_ALIVE:-5m}
+    restart: unless-stopped
+    healthcheck:
+      # The official ollama/ollama image ships curl in $PATH.
+      test: ["CMD-SHELL", "curl -fsS http://localhost:11434/api/tags || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  # --- orchestrator -----------------------------------------------------
+  orchestrator:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
+    image: orchestrator:slim
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_BASE_URL: http://ollama:11434
+      ORCH_LOG_LEVEL: ${ORCH_LOG_LEVEL:-INFO}
+      ORCH_RAM_HARD_CAP_MB: ${ORCH_RAM_HARD_CAP_MB:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+    ports:
+      - "${ORCH_HOST_PORT:-8000}:8000"
+    volumes:
+      - ./config:/etc/orchestrator:ro
+      - orch-data:/var/lib/orchestrator
+    restart: unless-stopped
+
+  # --- one-shot init: pull models, then exit ----------------------------
+  # Activated only via the `init` profile so it does not run on
+  # `docker compose up`. Run with:
+  #   docker compose --profile init up ollama-init
+  ollama-init:
+    image: ollama/ollama:latest
+    profiles: ["init"]
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+      # Whitespace-separated list of model tags to pre-pull.
+      OLLAMA_MODELS: ${OLLAMA_MODELS:-qwen2.5:7b qwen2.5-coder:7b qwen2.5:1.5b}
+    entrypoint: ["/bin/sh", "-lc"]
+    command:
+      - |
+        set -eu
+        echo "Pre-pulling models against $$OLLAMA_HOST: $$OLLAMA_MODELS"
+        for m in $$OLLAMA_MODELS; do
+          echo ">>> ollama pull $$m"
+          ollama pull "$$m"
+        done
+        echo "All models pulled."
+    restart: "no"
+
+volumes:
+  # Project-prefixed (compose adds the `name:` above) so multiple checkouts
+  # don't collide: `orchestrator_ollama-models`, `orchestrator_orch-data`.
+  ollama-models:
+  orch-data:

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,36 @@
+# Copy to `docker-compose.override.yml` and edit to taste.
+# Compose auto-loads `docker-compose.override.yml` (or `compose.override.yaml`)
+# alongside the primary `compose.yaml` — no extra `-f` flags needed.
+#
+# Common local tweaks are listed below. Uncomment what you need.
+
+services:
+
+  # --- bind a different host port for the orchestrator -------------------
+  # orchestrator:
+  #   ports:
+  #     - "18000:8000"
+
+  # --- expose Ollama directly on the host (e.g. to share with another
+  # tool on the workstation) --------------------------------------------
+  # ollama:
+  #   ports:
+  #     - "11434:11434"
+
+  # --- swap to the NVIDIA GPU runtime for Ollama -------------------------
+  # Requires the NVIDIA Container Toolkit on the host.
+  # ollama:
+  #   deploy:
+  #     resources:
+  #       reservations:
+  #         devices:
+  #           - driver: nvidia
+  #             count: all
+  #             capabilities: ["gpu"]
+
+  # --- mount a host-side Playwright cache for the browser variant -------
+  # Useful when the orchestrator image is built from `Dockerfile.browser`
+  # and you want to reuse a Chromium download already on disk.
+  # orchestrator:
+  #   volumes:
+  #     - ${HOME}/.cache/ms-playwright:/home/orchestrator/.cache/ms-playwright

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -159,6 +159,68 @@ Confirm you built the slim image with `--target runtime` (not the
 docker image ls orchestrator:slim --format '{{.Size}}'
 ```
 
+## Quick start with docker compose
+
+The repo ships a `compose.yaml` that brings up the orchestrator together
+with a local Ollama. This is the recommended way to run the stack on a
+workstation that doesn't already have Ollama installed.
+
+```bash
+git clone https://github.com/skgandikota/orchestrator.git
+cd orchestrator
+
+cp .env.example .env
+${EDITOR:-vi} .env          # fill in any free-tier API keys you want active
+
+# 1. First-time model pre-pull (one-shot, ~10–20 min on a fresh machine).
+docker compose --profile init up --exit-code-from ollama-init ollama-init
+
+# 2. Start the stack.
+docker compose up -d
+
+# 3. Smoke test.
+curl -fsS http://localhost:8000/v1/models
+```
+
+### Workflows
+
+| Goal | Command |
+| --- | --- |
+| Cold start (models already pulled) | `docker compose up -d` |
+| Pre-pull / refresh models | `docker compose --profile init up ollama-init` |
+| Tail orchestrator + ollama logs | `docker compose logs -f --tail=200` |
+| Exec a shell in the orchestrator | `docker compose exec orchestrator sh` |
+| Stop, keep volumes (model cache + data) | `docker compose down` |
+| Stop **and wipe** model cache + data | `docker compose down -v` |
+
+### Browser-fallback variant
+
+```bash
+docker compose -f compose.yaml -f compose.browser.yaml up -d
+```
+
+The overlay swaps the orchestrator build to `Dockerfile.browser` so the
+optional browser-fallback search path (#9) works without mounting a host
+Playwright cache.
+
+### Customizing the deployment
+
+Copy `docker-compose.override.yml.example` to `docker-compose.override.yml`
+and uncomment the snippet you need (different host port, expose Ollama on
+the host, switch Ollama to the NVIDIA GPU runtime, mount a Playwright
+cache for the browser variant). Compose loads the override automatically.
+
+### Volumes
+
+The stack uses two named, project-prefixed volumes so multiple checkouts
+don't collide:
+
+- `orchestrator_ollama-models` — persists the Ollama model cache.
+- `orchestrator_orch-data` — orchestrator runtime data (SQLite cache, audit log).
+
+`docker compose down` leaves both intact. `docker compose down -v` removes
+them.
+
 ## Make targets
 
 For local convenience the top-level `Makefile` exposes:
@@ -166,4 +228,10 @@ For local convenience the top-level `Makefile` exposes:
 ```bash
 make docker-build   # build orchestrator:slim
 make docker-run     # run orchestrator:slim with sensible defaults
+
+make compose-up     # docker compose up -d
+make compose-init   # one-shot model pre-pull (profile: init)
+make compose-logs   # tail logs from the running stack
+make compose-pull   # refresh base images
+make compose-down   # stop the stack (keeps volumes)
 ```


### PR DESCRIPTION
Closes #47

## Acceptance Criteria met

- `compose.yaml` at repo root with `ollama` + `orchestrator` services. `ollama` uses `ollama/ollama:latest`, exposes `11434` only on the compose network (no host port-map), persists models to the named volume `ollama-models:/root/.ollama`, and healthchecks `/api/tags` via curl. `orchestrator` builds from local `Dockerfile` (target `runtime`), `depends_on: ollama (condition: service_healthy)`, sets `OLLAMA_BASE_URL=http://ollama:11434`, maps `8000:8000` (configurable via `ORCH_HOST_PORT`), mounts `./config:/etc/orchestrator:ro` + `orch-data:/var/lib/orchestrator`, `restart: unless-stopped`.
- One-shot `ollama-init` service (also defined in `compose.init.yaml` overlay) gated on the `init` profile, `restart: "no"`, runs `ollama pull` for each tag in `OLLAMA_MODELS` (default `qwen2.5:7b qwen2.5-coder:7b qwen2.5:1.5b`), then exits.
- `compose.browser.yaml` overlay swaps the orchestrator build to `Dockerfile.browser` for the browser-fallback variant.
- `docker-compose.override.yml.example` documents bind a different port, expose Ollama on the host, swap to NVIDIA GPU runtime, mount a host Playwright cache.
- `.env.example` lists every consumed env var (`ORCH_LOG_LEVEL`, `ORCH_RAM_HARD_CAP_MB`, `ORCH_HOST_PORT`, `OLLAMA_MODELS`, `OLLAMA_KEEP_ALIVE`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`) with comments.
- `docs/DEPLOY.md` gains a `Quick start with docker compose` section with copy-pasteable steps (clone → `cp .env.example .env` → fill keys → init pull → `docker compose up -d` → curl `localhost:8000/v1/models`) plus a workflows table covering cold start, init, logs, exec, `down`, `down -v`.
- Volumes are project-prefixed via `name: orchestrator` at the top of `compose.yaml` (resulting in `orchestrator_ollama-models` / `orchestrator_orch-data`) so multiple checkouts don't collide.
- `docker compose down` preserves volumes; `docker compose down -v` removes them — documented in the workflows table.
- `Makefile` adds `compose-up`, `compose-down`, `compose-init`, `compose-logs`, `compose-pull` targets (#51).

## Verification

- `python -c "import yaml; ..."` parses all four compose files cleanly (Docker daemon not available in this sandbox; `docker compose config` deferred to CI).
- `pytest --cov=orchestrator --cov-fail-under=95` — 275 passed, 1 skipped, total coverage 98.80%.

Config-only PR; no Python changes.
