### PR TITLE
feat(pipeline): consolidate step

### DIFF
--- a/orchestrator/core/pipeline/__init__.py
+++ b/orchestrator/core/pipeline/__init__.py
@@ -1,0 +1,40 @@
+"""Pipeline steps that turn a user message into an execution plan.
+
+This package hosts the deterministic, persistable steps of the Phase 3
+pipeline. Only the *consolidate* step lives here today -- ``classify``,
+``refine``, and ``plan`` land in their own issues.
+"""
+
+from __future__ import annotations
+
+from .bundle import (
+    Bundle,
+    ClassifyResult,
+    FileEntry,
+    JobStateSnapshot,
+    Message,
+    WorkspaceSummary,
+)
+from .consolidate import (
+    DEFAULT_MAX_FILES,
+    DEFAULT_RECENT_MESSAGES,
+    EXCLUDED_DIRS,
+    MAX_FILE_SIZE_BYTES,
+    PipelineState,
+    consolidate,
+)
+
+__all__ = [
+    "DEFAULT_MAX_FILES",
+    "DEFAULT_RECENT_MESSAGES",
+    "EXCLUDED_DIRS",
+    "MAX_FILE_SIZE_BYTES",
+    "Bundle",
+    "ClassifyResult",
+    "FileEntry",
+    "JobStateSnapshot",
+    "Message",
+    "PipelineState",
+    "WorkspaceSummary",
+    "consolidate",
+]

--- a/orchestrator/core/pipeline/bundle.py
+++ b/orchestrator/core/pipeline/bundle.py
@@ -1,0 +1,91 @@
+"""Pydantic models for the consolidate step.
+
+These models are kept flat and JSON-serialisable so the resulting
+:class:`Bundle` can be checkpointed straight into SQLite via
+``model_dump_json()`` and round-trip back.
+
+Other pipeline steps (``refine``, ``plan``) import their input shape from
+this module so they don't have to take a transitive dependency on
+``consolidate.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "Bundle",
+    "ClassifyResult",
+    "FileEntry",
+    "JobStateSnapshot",
+    "Message",
+    "WorkspaceSummary",
+]
+
+
+MessageRole = Literal["system", "user", "assistant", "tool"]
+
+
+class _Frozen(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class Message(_Frozen):
+    """A single chat-style message in the conversation history."""
+
+    role: MessageRole
+    content: str
+    created_at: datetime | None = None
+
+
+class FileEntry(_Frozen):
+    """One entry in the workspace summary -- path + size only, no contents."""
+
+    path: str
+    size_bytes: int = Field(ge=0)
+
+
+class WorkspaceSummary(_Frozen):
+    """A coarse, content-free description of the workspace directory."""
+
+    root: str
+    files: list[FileEntry] = Field(default_factory=list)
+    truncated: bool = False
+
+
+class JobStateSnapshot(_Frozen):
+    """A point-in-time projection of the durable job record."""
+
+    job_id: str
+    status: str
+    attempt: int = Field(default=0, ge=0)
+    last_step: str | None = None
+    updated_at: datetime | None = None
+
+
+class ClassifyResult(_Frozen):
+    """Output of the ``classify`` step (#37) -- redefined here as the contract.
+
+    The full implementation lives in the classify module; we only require the
+    fields ``consolidate`` actually carries forward.
+    """
+
+    intent: str
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class Bundle(BaseModel):
+    """The deterministic, serialisable artefact produced by ``consolidate``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    job_id: str
+    user_msg: str
+    recent_messages: list[Message] = Field(default_factory=list)
+    workspace_summary: WorkspaceSummary
+    recent_job_state: JobStateSnapshot
+    classification: ClassifyResult

--- a/orchestrator/core/pipeline/consolidate.py
+++ b/orchestrator/core/pipeline/consolidate.py
@@ -1,0 +1,184 @@
+"""The pipeline ``consolidate`` step.
+
+Gathers the user message, recent conversation history, a coarse workspace
+summary, and the latest durable job-state snapshot into a single
+:class:`Bundle`. The bundle is checkpointed to the durable state store via
+``append_pipeline_event`` *before* it is returned, so a crash mid-pipeline
+is recoverable.
+
+This step performs no LLM calls and reads no file contents -- it is a pure
+context-gathering step.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol
+
+import pathspec
+
+from ..workspace import WorkspaceLike
+from .bundle import (
+    Bundle,
+    ClassifyResult,
+    FileEntry,
+    JobStateSnapshot,
+    Message,
+    WorkspaceSummary,
+)
+
+__all__ = [
+    "DEFAULT_MAX_FILES",
+    "DEFAULT_RECENT_MESSAGES",
+    "EXCLUDED_DIRS",
+    "MAX_FILE_SIZE_BYTES",
+    "PipelineState",
+    "consolidate",
+]
+
+#: Directories that are never useful to the pipeline summary.
+EXCLUDED_DIRS: frozenset[str] = frozenset({".git", "node_modules", "__pycache__", ".venv"})
+
+#: Maximum size of a single file before it's excluded from the summary.
+MAX_FILE_SIZE_BYTES: int = 1 * 1024 * 1024  # 1 MiB
+
+#: Default cap on the number of files in :class:`WorkspaceSummary`.
+DEFAULT_MAX_FILES: int = 500
+
+#: Default number of recent messages to include in the bundle.
+DEFAULT_RECENT_MESSAGES: int = 20
+
+
+class PipelineState(Protocol):
+    """Subset of the durable state store used by the consolidate step."""
+
+    def recent_messages(self, job_id: str, limit: int) -> Iterable[Message]: ...
+
+    def get_job_state(self, job_id: str) -> JobStateSnapshot: ...
+
+    def append_pipeline_event(
+        self, job_id: str, *, step: str, payload: dict[str, object]
+    ) -> None: ...
+
+
+def _path_excluded_by_dirs(rel_path: str) -> bool:
+    parts = rel_path.split("/")
+    return any(part in EXCLUDED_DIRS for part in parts)
+
+
+def _build_gitignore_matcher(text: str | None) -> pathspec.PathSpec | None:
+    if not text:
+        return None
+    return pathspec.PathSpec.from_lines("gitwildmatch", text.splitlines())
+
+
+def _summarise_workspace(
+    workspace: WorkspaceLike,
+    *,
+    max_files: int,
+    max_file_size_bytes: int,
+) -> WorkspaceSummary:
+    matcher = _build_gitignore_matcher(workspace.read_gitignore())
+    entries: list[FileEntry] = []
+    truncated = False
+
+    for stat in workspace.walk_files():
+        if _path_excluded_by_dirs(stat.path):
+            continue
+        if stat.size_bytes > max_file_size_bytes:
+            continue
+        if matcher is not None and matcher.match_file(stat.path):
+            continue
+        if len(entries) >= max_files:
+            truncated = True
+            break
+        entries.append(FileEntry(path=stat.path, size_bytes=stat.size_bytes))
+
+    entries.sort(key=lambda e: e.path)
+    return WorkspaceSummary(root=workspace.root, files=entries, truncated=truncated)
+
+
+def _truncate_history(
+    messages: Iterable[Message],
+    *,
+    limit: int,
+    token_budget: int | None,
+) -> list[Message]:
+    items = list(messages)
+    if limit >= 0:
+        items = items[-limit:] if limit else []
+    if token_budget is None or token_budget < 0:
+        return items
+    # Rough heuristic: 1 token ~= 4 chars. Drop oldest until we fit.
+    budget_chars = token_budget * 4
+    total = sum(len(m.content) for m in items)
+    while items and total > budget_chars:
+        dropped = items.pop(0)
+        total -= len(dropped.content)
+    return items
+
+
+def consolidate(
+    job_id: str,
+    user_msg: str,
+    classification: ClassifyResult,
+    *,
+    state: PipelineState,
+    workspace: WorkspaceLike,
+    recent_messages_limit: int = DEFAULT_RECENT_MESSAGES,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_file_size_bytes: int = MAX_FILE_SIZE_BYTES,
+    history_token_budget: int | None = None,
+) -> Bundle:
+    """Build a :class:`Bundle` and checkpoint it before returning.
+
+    Args:
+        job_id: ID of the job this pipeline run belongs to.
+        user_msg: The latest user message that triggered the pipeline.
+        classification: Output of the upstream ``classify`` step.
+        state: Durable state-store handle (see :class:`PipelineState`).
+        workspace: Workspace abstraction used to summarise the project tree.
+        recent_messages_limit: Max number of recent messages to carry forward.
+            Defaults to :data:`DEFAULT_RECENT_MESSAGES`.
+        max_files: Cap on entries in the workspace summary.
+        max_file_size_bytes: Files larger than this are excluded.
+        history_token_budget: Optional rough token budget for the recent
+            messages. When set, oldest messages are dropped first until the
+            estimated total fits within ``budget * 4`` characters.
+
+    Raises:
+        ValueError: If ``job_id`` or ``user_msg`` is empty.
+    """
+
+    if not job_id:
+        raise ValueError("job_id must not be empty")
+    if not user_msg:
+        raise ValueError("user_msg must not be empty")
+
+    history = _truncate_history(
+        state.recent_messages(job_id, recent_messages_limit),
+        limit=recent_messages_limit,
+        token_budget=history_token_budget,
+    )
+    job_state = state.get_job_state(job_id)
+    summary = _summarise_workspace(
+        workspace,
+        max_files=max_files,
+        max_file_size_bytes=max_file_size_bytes,
+    )
+
+    bundle = Bundle(
+        job_id=job_id,
+        user_msg=user_msg,
+        recent_messages=history,
+        workspace_summary=summary,
+        recent_job_state=job_state,
+        classification=classification,
+    )
+
+    state.append_pipeline_event(
+        job_id,
+        step="consolidate",
+        payload=bundle.model_dump(mode="json"),
+    )
+    return bundle

--- a/orchestrator/core/workspace.py
+++ b/orchestrator/core/workspace.py
@@ -1,0 +1,90 @@
+"""Workspace abstraction for the pipeline.
+
+A :class:`Workspace` is a thin wrapper around a directory on disk that the
+pipeline reads to build a :class:`~orchestrator.core.pipeline.bundle.WorkspaceSummary`.
+The wrapper exists so that file-system access is mockable in unit tests --
+production code goes through :class:`Workspace`, tests can substitute a
+:class:`FakeWorkspace` (or any object with a compatible ``walk_files`` and
+``read_gitignore`` surface).
+
+The wrapper deliberately does **not** read file contents -- that is the job
+of the coder/executor downstream. We only expose ``(relative_path, size_bytes)``
+tuples plus the optional ``.gitignore`` text.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+__all__ = ["FileStat", "Workspace", "WorkspaceLike"]
+
+
+@dataclass(frozen=True)
+class FileStat:
+    """A file's ``(relative path, size in bytes)`` tuple."""
+
+    path: str
+    size_bytes: int
+
+
+class WorkspaceLike(Protocol):
+    """Structural type satisfied by both :class:`Workspace` and test fakes."""
+
+    @property
+    def root(self) -> str: ...
+
+    def walk_files(self) -> Iterator[FileStat]: ...
+
+    def read_gitignore(self) -> str | None: ...
+
+
+class Workspace:
+    """Disk-backed workspace.
+
+    Args:
+        root: Directory on disk to summarise. Need not exist; a missing root
+            yields an empty file list.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self._root = Path(root)
+
+    @property
+    def root(self) -> str:
+        return str(self._root)
+
+    def walk_files(self) -> Iterator[FileStat]:
+        """Yield every regular file beneath the root with its size in bytes.
+
+        Symlinks and non-regular files are skipped. Files we cannot stat
+        (permission errors, races) are silently skipped -- the workspace
+        summary is best-effort.
+        """
+
+        root = self._root
+        if not root.is_dir():
+            return
+        for entry in root.rglob("*"):
+            try:
+                if not entry.is_file() or entry.is_symlink():
+                    continue
+                size = entry.stat().st_size
+            except OSError:
+                continue
+            try:
+                rel = entry.relative_to(root).as_posix()
+            except ValueError:
+                continue
+            yield FileStat(path=rel, size_bytes=size)
+
+    def read_gitignore(self) -> str | None:
+        """Return the workspace's ``.gitignore`` text, or ``None`` if absent."""
+
+        gi = self._root / ".gitignore"
+        try:
+            return gi.read_text(encoding="utf-8")
+        except (FileNotFoundError, IsADirectoryError, OSError):
+            return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ dependencies = [
     "duckduckgo-search>=6.0",
     "mcp>=1.27.0,<2",
     "pyyaml>=6.0",
-    "jsonschema>=4.21",
     "jsonschema>=4.26.0",
     "litellm>=1.50",
     "typer>=0.12",
+    "pathspec>=0.12",
 ]
 
 [project.scripts]

--- a/tests/core/pipeline/test_consolidate.py
+++ b/tests/core/pipeline/test_consolidate.py
@@ -1,0 +1,349 @@
+"""Tests for the pipeline consolidate step."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from orchestrator.core.pipeline import (
+    DEFAULT_MAX_FILES,
+    EXCLUDED_DIRS,
+    MAX_FILE_SIZE_BYTES,
+    Bundle,
+    ClassifyResult,
+    JobStateSnapshot,
+    Message,
+    WorkspaceSummary,
+    consolidate,
+)
+from orchestrator.core.workspace import FileStat, Workspace
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeWorkspace:
+    """In-memory :class:`WorkspaceLike` for tests."""
+
+    def __init__(
+        self,
+        root: str = "/tmp/fake-workspace",
+        files: Iterable[FileStat] = (),
+        gitignore: str | None = None,
+    ) -> None:
+        self._root = root
+        self._files = list(files)
+        self._gitignore = gitignore
+
+    @property
+    def root(self) -> str:
+        return self._root
+
+    def walk_files(self) -> Iterator[FileStat]:
+        yield from self._files
+
+    def read_gitignore(self) -> str | None:
+        return self._gitignore
+
+
+class FakeState:
+    """In-memory :class:`PipelineState`."""
+
+    def __init__(
+        self,
+        messages: Iterable[Message] = (),
+        job_state: JobStateSnapshot | None = None,
+    ) -> None:
+        self._messages = list(messages)
+        self._job_state = job_state or JobStateSnapshot(job_id="job-0", status="running")
+        self.events: list[dict[str, object]] = []
+        self.last_recent_messages_limit: int | None = None
+
+    def recent_messages(self, job_id: str, limit: int) -> list[Message]:
+        self.last_recent_messages_limit = limit
+        return list(self._messages)
+
+    def get_job_state(self, job_id: str) -> JobStateSnapshot:
+        return self._job_state
+
+    def append_pipeline_event(self, job_id: str, *, step: str, payload: dict[str, object]) -> None:
+        self.events.append({"job_id": job_id, "step": step, "payload": payload})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _classify() -> ClassifyResult:
+    return ClassifyResult(intent="code", confidence=0.9)
+
+
+def _msg(role: str, content: str) -> Message:
+    return Message(role=role, content=content, created_at=datetime(2024, 1, 1, tzinfo=UTC))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_consolidate_returns_bundle_and_checkpoints_before_return() -> None:
+    state = FakeState(
+        messages=[_msg("user", "hi"), _msg("assistant", "hey")],
+        job_state=JobStateSnapshot(job_id="j1", status="running", attempt=2),
+    )
+    ws = FakeWorkspace(files=[FileStat("a.txt", 10), FileStat("b.txt", 20)])
+
+    bundle = consolidate(
+        "j1",
+        "do the thing",
+        _classify(),
+        state=state,
+        workspace=ws,
+    )
+
+    assert isinstance(bundle, Bundle)
+    assert bundle.job_id == "j1"
+    assert bundle.user_msg == "do the thing"
+    assert [m.content for m in bundle.recent_messages] == ["hi", "hey"]
+    assert bundle.recent_job_state.attempt == 2
+    assert bundle.classification.intent == "code"
+    assert [f.path for f in bundle.workspace_summary.files] == ["a.txt", "b.txt"]
+    assert bundle.workspace_summary.truncated is False
+
+    assert len(state.events) == 1
+    ev = state.events[0]
+    assert ev["job_id"] == "j1"
+    assert ev["step"] == "consolidate"
+    payload = ev["payload"]
+    assert isinstance(payload, dict)
+    assert payload["user_msg"] == "do the thing"
+
+
+def test_bundle_is_json_round_trippable() -> None:
+    state = FakeState()
+    ws = FakeWorkspace(files=[FileStat("a.txt", 1)])
+    bundle = consolidate("j1", "msg", _classify(), state=state, workspace=ws)
+
+    raw = bundle.model_dump_json()
+    restored = Bundle.model_validate_json(raw)
+    assert restored == bundle
+    assert isinstance(json.loads(raw), dict)
+
+
+def test_empty_workspace_yields_empty_summary() -> None:
+    state = FakeState()
+    ws = FakeWorkspace(files=[])
+
+    bundle = consolidate("j1", "msg", _classify(), state=state, workspace=ws)
+
+    assert isinstance(bundle.workspace_summary, WorkspaceSummary)
+    assert bundle.workspace_summary.files == []
+    assert bundle.workspace_summary.truncated is False
+
+
+def test_large_files_are_excluded() -> None:
+    state = FakeState()
+    ws = FakeWorkspace(
+        files=[
+            FileStat("small.txt", 100),
+            FileStat("huge.bin", MAX_FILE_SIZE_BYTES + 1),
+            FileStat("at_limit.bin", MAX_FILE_SIZE_BYTES),
+        ]
+    )
+
+    bundle = consolidate("j1", "msg", _classify(), state=state, workspace=ws)
+    paths = {f.path for f in bundle.workspace_summary.files}
+    assert paths == {"small.txt", "at_limit.bin"}
+
+
+@pytest.mark.parametrize("excluded", sorted(EXCLUDED_DIRS))
+def test_excluded_directories_are_filtered(excluded: str) -> None:
+    state = FakeState()
+    ws = FakeWorkspace(
+        files=[
+            FileStat("src/main.py", 10),
+            FileStat(f"{excluded}/inside.txt", 10),
+            FileStat(f"nested/{excluded}/deep.txt", 10),
+        ]
+    )
+
+    bundle = consolidate("j1", "msg", _classify(), state=state, workspace=ws)
+    paths = {f.path for f in bundle.workspace_summary.files}
+    assert paths == {"src/main.py"}
+
+
+def test_gitignore_is_honoured() -> None:
+    state = FakeState()
+    ws = FakeWorkspace(
+        files=[
+            FileStat("keep.py", 10),
+            FileStat("build/out.bin", 10),
+            FileStat("notes.log", 10),
+        ],
+        gitignore="build/\n*.log\n",
+    )
+
+    bundle = consolidate("j1", "msg", _classify(), state=state, workspace=ws)
+    paths = {f.path for f in bundle.workspace_summary.files}
+    assert paths == {"keep.py"}
+
+
+def test_empty_gitignore_string_is_treated_as_absent() -> None:
+    state = FakeState()
+    ws = FakeWorkspace(files=[FileStat("a.txt", 1)], gitignore="")
+
+    bundle = consolidate("j1", "msg", _classify(), state=state, workspace=ws)
+    assert [f.path for f in bundle.workspace_summary.files] == ["a.txt"]
+
+
+def test_history_truncated_to_limit_oldest_first() -> None:
+    msgs = [_msg("user", f"m{i}") for i in range(10)]
+    state = FakeState(messages=msgs)
+    ws = FakeWorkspace()
+
+    bundle = consolidate(
+        "j1",
+        "msg",
+        _classify(),
+        state=state,
+        workspace=ws,
+        recent_messages_limit=3,
+    )
+    assert [m.content for m in bundle.recent_messages] == ["m7", "m8", "m9"]
+    assert state.last_recent_messages_limit == 3
+
+
+def test_history_token_budget_drops_oldest() -> None:
+    msgs = [_msg("user", "x" * 400) for _ in range(5)]  # ~100 tokens each
+    state = FakeState(messages=msgs)
+    ws = FakeWorkspace()
+
+    bundle = consolidate(
+        "j1",
+        "msg",
+        _classify(),
+        state=state,
+        workspace=ws,
+        recent_messages_limit=10,
+        history_token_budget=200,  # ~800 chars -> 2 messages
+    )
+    assert len(bundle.recent_messages) == 2
+
+
+def test_history_limit_zero_returns_no_messages() -> None:
+    state = FakeState(messages=[_msg("user", "hi")])
+    ws = FakeWorkspace()
+
+    bundle = consolidate(
+        "j1",
+        "msg",
+        _classify(),
+        state=state,
+        workspace=ws,
+        recent_messages_limit=0,
+    )
+    assert bundle.recent_messages == []
+
+
+def test_max_files_cap_marks_truncated() -> None:
+    state = FakeState()
+    ws = FakeWorkspace(files=[FileStat(f"f{i}.txt", 1) for i in range(5)])
+
+    bundle = consolidate(
+        "j1",
+        "msg",
+        _classify(),
+        state=state,
+        workspace=ws,
+        max_files=3,
+    )
+    assert len(bundle.workspace_summary.files) == 3
+    assert bundle.workspace_summary.truncated is True
+
+
+def test_default_max_files_constant() -> None:
+    assert DEFAULT_MAX_FILES == 500
+
+
+def test_empty_job_id_rejected() -> None:
+    state = FakeState()
+    ws = FakeWorkspace()
+    with pytest.raises(ValueError, match="job_id"):
+        consolidate("", "msg", _classify(), state=state, workspace=ws)
+
+
+def test_empty_user_msg_rejected() -> None:
+    state = FakeState()
+    ws = FakeWorkspace()
+    with pytest.raises(ValueError, match="user_msg"):
+        consolidate("j1", "", _classify(), state=state, workspace=ws)
+
+
+# ---------------------------------------------------------------------------
+# Workspace (disk-backed) tests
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_walk_excludes_symlinks_and_missing_root(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    ws = Workspace(missing)
+    assert list(ws.walk_files()) == []
+    assert ws.read_gitignore() is None
+
+
+def test_workspace_walk_yields_relative_paths(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("hello")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "b.txt").write_text("world!")
+
+    ws = Workspace(tmp_path)
+    found = {(s.path, s.size_bytes) for s in ws.walk_files()}
+    assert ("a.txt", 5) in found
+    assert ("sub/b.txt", 6) in found
+    assert ws.root == str(tmp_path)
+
+
+def test_workspace_read_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("*.log\n")
+    ws = Workspace(tmp_path)
+    assert ws.read_gitignore() == "*.log\n"
+
+
+def test_workspace_skips_unreadable_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "a.txt").write_text("x")
+    (tmp_path / "b.txt").write_text("y")
+    ws = Workspace(tmp_path)
+
+    real_stat = Path.stat
+
+    def flaky_stat(self: Path, *args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        if self.name == "b.txt":
+            raise OSError("nope")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", flaky_stat)
+    paths = {s.path for s in ws.walk_files()}
+    assert paths == {"a.txt"}
+
+
+def test_workspace_integration_with_consolidate(tmp_path: Path) -> None:
+    (tmp_path / "keep.py").write_text("print('hi')")
+    (tmp_path / ".gitignore").write_text("ignored.txt\n")
+    (tmp_path / "ignored.txt").write_text("nope")
+    excluded_dir = tmp_path / "__pycache__"
+    excluded_dir.mkdir()
+    (excluded_dir / "x.pyc").write_text("bytes")
+
+    state = FakeState()
+    bundle = consolidate("j1", "msg", _classify(), state=state, workspace=Workspace(tmp_path))
+    assert {f.path for f in bundle.workspace_summary.files} == {".gitignore", "keep.py"}


### PR DESCRIPTION
Closes #39

## Summary

Implements the Phase 3 pipeline `consolidate` step: gathers the user message, recent conversation history, a content-free workspace summary, and the latest job-state snapshot into a deterministic, JSON-serialisable `Bundle`. The bundle is checkpointed via `state.append_pipeline_event` **before** it is returned, so a crash mid-pipeline is recoverable.

## Files

- `orchestrator/core/pipeline/__init__.py` — package surface
- `orchestrator/core/pipeline/bundle.py` — `Bundle` / `WorkspaceSummary` / `FileEntry` / `Message` / `JobStateSnapshot` / `ClassifyResult` Pydantic models
- `orchestrator/core/pipeline/consolidate.py` — `consolidate(...)` plus `PipelineState` Protocol
- `orchestrator/core/workspace.py` — disk-backed `Workspace` + `WorkspaceLike` Protocol (mockable)
- `pyproject.toml` — adds `pathspec` runtime dep for `.gitignore` handling
- `tests/core/pipeline/test_consolidate.py` — fakes for state + workspace; 22 tests

## Acceptance Criteria met

- [x] `Bundle` Pydantic model with required fields
- [x] `WorkspaceSummary` with `root` + `list[FileEntry]` (path + size only, no contents)
- [x] `consolidate(job_id, user_msg, classification, *, state, workspace) -> Bundle`
- [x] Recent-messages limit configurable (default 20) with token-budget heuristic, oldest dropped first
- [x] Workspace summary excludes `.git/`, `node_modules/`, `__pycache__/`, `.venv/`, files > 1 MiB, and respects `.gitignore`
- [x] Bundle checkpointed via `state.append_pipeline_event` before return
- [x] Unit tests: empty workspace, large file exclusion, gitignore handling, history truncation, checkpoint write
- [x] All I/O goes through the `Workspace` abstraction (mockable)
- [x] `Bundle.model_dump_json()` round-trips
- [x] `ruff check` clean
- [x] Coverage 98.76% (>= 95%)
