### PR TITLE
feat(cli): orchestrator command-line interface

### DIFF
--- a/orchestrator/interfaces/cli.py
+++ b/orchestrator/interfaces/cli.py
@@ -186,9 +186,7 @@ def submit(
 def status(
     ctx: typer.Context,
     job_id: Annotated[str, typer.Argument(help="Job id returned by ``submit``.")],
-    mode: Annotated[
-        str | None, typer.Option("--mode", help="Detail mode: a, b, or c.")
-    ] = None,
+    mode: Annotated[str | None, typer.Option("--mode", help="Detail mode: a, b, or c.")] = None,
 ) -> None:
     """Print the status payload for ``job_id``."""
     params = {"mode": mode} if mode else None
@@ -237,9 +235,10 @@ def models(ctx: typer.Context) -> None:
 def _stream_job(base_url: str, job_id: str) -> None:
     """Tail the SSE endpoint and print every ``data:`` payload."""
     try:
-        with _client(base_url, timeout=None) as client, client.stream(
-            "GET", f"/v1/jobs/{job_id}/stream"
-        ) as resp:
+        with (
+            _client(base_url, timeout=None) as client,
+            client.stream("GET", f"/v1/jobs/{job_id}/stream") as resp,
+        ):
             resp.raise_for_status()
             for line in resp.iter_lines():
                 if not line:

--- a/orchestrator/interfaces/cli.py
+++ b/orchestrator/interfaces/cli.py
@@ -1,22 +1,53 @@
-"""Operator-facing helpers for recoverable jobs.
+"""Top-level command-line interface for the orchestrator.
 
-Surfaces jobs that the startup recovery pass (see
-:mod:`orchestrator.core.recovery`) flipped to ``recoverable`` so the user can
-choose to ``resume`` or ``cancel`` each one.
+This is a thin client of the local HTTP API exposed by
+:mod:`orchestrator.interfaces.server`.  It is intentionally small: each
+subcommand either delegates to a long-running server entry point
+(``serve``/``mcp``) or talks to the HTTP API over :mod:`httpx`.
+
+The module also re-exports a few operator-facing helpers
+(:func:`list_recoverable`, :func:`resume_job`, :func:`cancel_job`) used by
+the recovery surface in :mod:`orchestrator.core.recovery`.
 """
 
 from __future__ import annotations
 
+import json
+import os
 from collections.abc import Iterable
+from importlib import import_module
+from typing import Annotated, Any
+
+import httpx
+import typer
 
 from orchestrator.core.recovery import Job, StateStore, cancel, resume
 
-__all__ = ["cancel_job", "list_recoverable", "resume_job"]
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "ENV_BASE_URL",
+    "app",
+    "cancel_job",
+    "list_recoverable",
+    "resume_job",
+]
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8000"
+ENV_BASE_URL = "ORCHESTRATOR_URL"
+
+app = typer.Typer(
+    name="orchestrator",
+    help="Thin CLI client of the local orchestrator HTTP API.",
+    no_args_is_help=True,
+    add_completion=False,
+)
 
 
+# --------------------------------------------------------------------------- #
+# Operator helpers (kept for backwards-compatibility with recovery surface).  #
+# --------------------------------------------------------------------------- #
 def list_recoverable(state: StateStore) -> list[Job]:
     """Return every job currently in the ``recoverable`` state."""
-
     jobs: Iterable[Job] = state.list_recoverable()
     return list(jobs)
 
@@ -27,3 +58,199 @@ def resume_job(state: StateStore, job_id: str) -> None:
 
 def cancel_job(state: StateStore, job_id: str) -> None:
     cancel(state, job_id)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+def _resolve_base_url(override: str | None) -> str:
+    if override:
+        return override
+    return os.environ.get(ENV_BASE_URL, DEFAULT_BASE_URL)
+
+
+def _get_base_url(ctx: typer.Context) -> str:
+    obj = ctx.obj or {}
+    return str(obj.get("base_url", DEFAULT_BASE_URL))
+
+
+def _client(base_url: str, *, timeout: float | None = 30.0) -> httpx.Client:
+    return httpx.Client(base_url=base_url, timeout=timeout)
+
+
+def _abort(message: str, code: int = 1) -> None:
+    typer.echo(f"error: {message}", err=True)
+    raise typer.Exit(code=code)
+
+
+def _request_json(
+    method: str,
+    base_url: str,
+    path: str,
+    *,
+    json_body: dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    try:
+        with _client(base_url) as client:
+            resp = client.request(method, path, json=json_body, params=params)
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPStatusError as exc:
+        _abort(f"HTTP {exc.response.status_code}: {exc.response.text.strip()}", code=2)
+    except httpx.HTTPError as exc:
+        _abort(f"request failed: {exc}", code=2)
+
+
+# --------------------------------------------------------------------------- #
+# Root callback (global options)                                              #
+# --------------------------------------------------------------------------- #
+@app.callback()
+def _root(
+    ctx: typer.Context,
+    base_url: Annotated[
+        str | None,
+        typer.Option(
+            "--base-url",
+            help=(
+                "Base URL of the orchestrator HTTP API. "
+                f"Falls back to ${ENV_BASE_URL} or {DEFAULT_BASE_URL}."
+            ),
+        ),
+    ] = None,
+) -> None:
+    ctx.obj = {"base_url": _resolve_base_url(base_url)}
+
+
+# --------------------------------------------------------------------------- #
+# Server / MCP entrypoints (lazy imports)                                     #
+# --------------------------------------------------------------------------- #
+@app.command()
+def serve(
+    host: Annotated[str, typer.Option("--host", help="Bind address.")] = "127.0.0.1",
+    port: Annotated[int, typer.Option("--port", help="Bind port.")] = 8000,
+) -> None:
+    """Run the FastAPI/uvicorn HTTP server."""
+    try:
+        server = import_module("orchestrator.interfaces.server")
+    except ImportError as exc:  # pragma: no cover - import error is environment-specific
+        _abort(f"server module unavailable: {exc}")
+    runner = getattr(server, "run", None)
+    if runner is None:
+        _abort("orchestrator.interfaces.server.run is not defined")
+    runner(host=host, port=port)
+
+
+@app.command()
+def mcp() -> None:
+    """Run the MCP stdio server."""
+    try:
+        mcp_server = import_module("orchestrator.interfaces.mcp_server")
+    except ImportError as exc:  # pragma: no cover
+        _abort(f"mcp module unavailable: {exc}")
+    runner = getattr(mcp_server, "run", None)
+    if runner is None:
+        _abort("orchestrator.interfaces.mcp_server.run is not defined")
+    runner()
+
+
+# --------------------------------------------------------------------------- #
+# HTTP-talking subcommands                                                    #
+# --------------------------------------------------------------------------- #
+@app.command()
+def submit(
+    ctx: typer.Context,
+    message: Annotated[str, typer.Argument(help="Goal/message to submit.")],
+    model: Annotated[
+        str | None, typer.Option("--model", help="Override the default model id.")
+    ] = None,
+    stream: Annotated[
+        bool, typer.Option("--stream", help="Stream the SSE output after submission.")
+    ] = False,
+) -> None:
+    """POST a new job and print its ``job_id`` (optionally tailing output)."""
+    base = _get_base_url(ctx)
+    payload: dict[str, Any] = {"message": message}
+    if model is not None:
+        payload["model"] = model
+    data = _request_json("POST", base, "/v1/jobs", json_body=payload)
+    job_id = data.get("job_id") if isinstance(data, dict) else None
+    if not job_id:
+        _abort("response did not contain a job_id")
+    typer.echo(job_id)
+    if stream:
+        _stream_job(base, str(job_id))
+
+
+@app.command()
+def status(
+    ctx: typer.Context,
+    job_id: Annotated[str, typer.Argument(help="Job id returned by ``submit``.")],
+    mode: Annotated[
+        str | None, typer.Option("--mode", help="Detail mode: a, b, or c.")
+    ] = None,
+) -> None:
+    """Print the status payload for ``job_id``."""
+    params = {"mode": mode} if mode else None
+    data = _request_json("GET", _get_base_url(ctx), f"/v1/jobs/{job_id}", params=params)
+    typer.echo(json.dumps(data, indent=2, sort_keys=True))
+
+
+@app.command()
+def stream(
+    ctx: typer.Context,
+    job_id: Annotated[str, typer.Argument(help="Job id to tail.")],
+) -> None:
+    """Tail the SSE stream of ``job_id`` to stdout."""
+    _stream_job(_get_base_url(ctx), job_id)
+
+
+@app.command(name="cancel")
+def cancel_cmd(
+    ctx: typer.Context,
+    job_id: Annotated[str, typer.Argument(help="Job id to cancel.")],
+) -> None:
+    """Cancel a running job."""
+    _request_json("POST", _get_base_url(ctx), f"/v1/jobs/{job_id}/cancel")
+    typer.echo(f"cancelled {job_id}")
+
+
+@app.command()
+def models(ctx: typer.Context) -> None:
+    """List the models exposed by the local API (``GET /v1/models``)."""
+    data = _request_json("GET", _get_base_url(ctx), "/v1/models")
+    items: list[Any] = []
+    if isinstance(data, dict):
+        items = list(data.get("data") or data.get("models") or [])
+    elif isinstance(data, list):
+        items = data
+    if not items:
+        typer.echo("(no models)")
+        return
+    for item in items:
+        if isinstance(item, dict):
+            typer.echo(str(item.get("id") or item.get("name") or item))
+        else:
+            typer.echo(str(item))
+
+
+def _stream_job(base_url: str, job_id: str) -> None:
+    """Tail the SSE endpoint and print every ``data:`` payload."""
+    try:
+        with _client(base_url, timeout=None) as client, client.stream(
+            "GET", f"/v1/jobs/{job_id}/stream"
+        ) as resp:
+            resp.raise_for_status()
+            for line in resp.iter_lines():
+                if not line:
+                    continue
+                if line.startswith("data:"):
+                    typer.echo(line[len("data:") :].lstrip())
+    except httpx.HTTPStatusError as exc:
+        _abort(f"HTTP {exc.response.status_code}: {exc.response.text.strip()}", code=2)
+    except httpx.HTTPError as exc:
+        _abort(f"stream failed: {exc}", code=2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,12 @@ dependencies = [
     "pyyaml>=6.0",
     "jsonschema>=4.21",
     "jsonschema>=4.26.0",
-    "jsonschema>=4.21",
     "litellm>=1.50",
+    "typer>=0.12",
 ]
 
 [project.scripts]
-orchestrator = "orchestrator.cli:main"
+orchestrator = "orchestrator.interfaces.cli:app"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/interfaces/test_cli_app.py
+++ b/tests/interfaces/test_cli_app.py
@@ -24,9 +24,7 @@ runner = CliRunner(mix_stderr=False)
 # --------------------------------------------------------------------------- #
 # Helpers                                                                     #
 # --------------------------------------------------------------------------- #
-def _install_transport(
-    monkeypatch: pytest.MonkeyPatch, handler: Any
-) -> list[httpx.Request]:
+def _install_transport(monkeypatch: pytest.MonkeyPatch, handler: Any) -> list[httpx.Request]:
     """Replace ``cli._client`` with a client that uses a MockTransport."""
     captured: list[httpx.Request] = []
 
@@ -170,9 +168,7 @@ def test_submit_honors_env_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_submit_missing_job_id(monkeypatch: pytest.MonkeyPatch) -> None:
-    _install_transport(
-        monkeypatch, lambda r: httpx.Response(200, json={"unexpected": True})
-    )
+    _install_transport(monkeypatch, lambda r: httpx.Response(200, json={"unexpected": True}))
     result = runner.invoke(app, ["submit", "x"])
     assert result.exit_code == 1
     assert "job_id" in result.stderr
@@ -197,9 +193,7 @@ def test_submit_with_stream(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_submit_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    _install_transport(
-        monkeypatch, lambda r: httpx.Response(500, text="boom")
-    )
+    _install_transport(monkeypatch, lambda r: httpx.Response(500, text="boom"))
     result = runner.invoke(app, ["submit", "x"])
     assert result.exit_code == 2
     assert "HTTP 500" in result.stderr

--- a/tests/interfaces/test_cli_app.py
+++ b/tests/interfaces/test_cli_app.py
@@ -1,0 +1,325 @@
+"""Tests for the typer-based ``orchestrator`` CLI app."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from orchestrator.interfaces import cli as cli_mod
+from orchestrator.interfaces.cli import (
+    DEFAULT_BASE_URL,
+    ENV_BASE_URL,
+    _resolve_base_url,
+    app,
+)
+
+runner = CliRunner(mix_stderr=False)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+def _install_transport(
+    monkeypatch: pytest.MonkeyPatch, handler: Any
+) -> list[httpx.Request]:
+    """Replace ``cli._client`` with a client that uses a MockTransport."""
+    captured: list[httpx.Request] = []
+
+    def _wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(_wrapped)
+
+    def _factory(base_url: str, *, timeout: float | None = 30.0) -> httpx.Client:
+        return httpx.Client(base_url=base_url, timeout=timeout, transport=transport)
+
+    monkeypatch.setattr(cli_mod, "_client", _factory)
+    return captured
+
+
+# --------------------------------------------------------------------------- #
+# Base-URL resolution                                                         #
+# --------------------------------------------------------------------------- #
+def test_resolve_base_url_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_BASE_URL, raising=False)
+    assert _resolve_base_url(None) == DEFAULT_BASE_URL
+
+
+def test_resolve_base_url_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_BASE_URL, "http://api.example.test:9000")
+    assert _resolve_base_url(None) == "http://api.example.test:9000"
+
+
+def test_resolve_base_url_flag_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_BASE_URL, "http://api.example.test:9000")
+    assert _resolve_base_url("http://flag.example.test") == "http://flag.example.test"
+
+
+# --------------------------------------------------------------------------- #
+# Root callback / help                                                        #
+# --------------------------------------------------------------------------- #
+def test_help_lists_all_subcommands() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for sub in ("serve", "mcp", "submit", "status", "stream", "cancel", "models"):
+        assert sub in result.stdout
+
+
+def test_no_args_shows_help() -> None:
+    result = runner.invoke(app, [])
+    # typer/click exits with code 2 when no_args_is_help triggers
+    assert result.exit_code in (0, 2)
+    assert "Usage" in (result.stdout + result.stderr)
+
+
+# --------------------------------------------------------------------------- #
+# serve / mcp lazy entrypoints                                                #
+# --------------------------------------------------------------------------- #
+def test_serve_invokes_server_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MagicMock()
+    fake_module = MagicMock(run=fake)
+    monkeypatch.setattr(
+        cli_mod, "import_module", lambda name: fake_module if "server" in name else None
+    )
+    result = runner.invoke(app, ["serve", "--host", "0.0.0.0", "--port", "9001"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    fake.assert_called_once_with(host="0.0.0.0", port=9001)
+
+
+def test_serve_missing_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_mod, "import_module", lambda name: object())
+    result = runner.invoke(app, ["serve"])
+    assert result.exit_code == 1
+    assert "run is not defined" in result.stderr
+
+
+def test_mcp_invokes_mcp_server_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MagicMock()
+    fake_module = MagicMock(run=fake)
+    monkeypatch.setattr(cli_mod, "import_module", lambda name: fake_module)
+    result = runner.invoke(app, ["mcp"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    fake.assert_called_once_with()
+
+
+def test_mcp_missing_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_mod, "import_module", lambda name: object())
+    result = runner.invoke(app, ["mcp"])
+    assert result.exit_code == 1
+    assert "run is not defined" in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# submit                                                                      #
+# --------------------------------------------------------------------------- #
+def test_submit_prints_job_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/v1/jobs"
+        body = json.loads(request.content.decode())
+        assert body == {"message": "do a thing"}
+        return httpx.Response(200, json={"job_id": "j-123"})
+
+    captured = _install_transport(monkeypatch, handler)
+    result = runner.invoke(app, ["submit", "do a thing"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "j-123"
+    assert len(captured) == 1
+
+
+def test_submit_with_model_and_base_url_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.example.test"
+        body = json.loads(request.content.decode())
+        assert body == {"message": "go", "model": "llama3"}
+        return httpx.Response(200, json={"job_id": "j-9"})
+
+    _install_transport(monkeypatch, handler)
+    result = runner.invoke(
+        app,
+        [
+            "--base-url",
+            "http://api.example.test:7000",
+            "submit",
+            "go",
+            "--model",
+            "llama3",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "j-9" in result.stdout
+
+
+def test_submit_honors_env_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_BASE_URL, "http://from-env.test:8123")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "from-env.test"
+        return httpx.Response(200, json={"job_id": "env-job"})
+
+    _install_transport(monkeypatch, handler)
+    result = runner.invoke(app, ["submit", "hi"])
+    assert result.exit_code == 0
+    assert "env-job" in result.stdout
+
+
+def test_submit_missing_job_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_transport(
+        monkeypatch, lambda r: httpx.Response(200, json={"unexpected": True})
+    )
+    result = runner.invoke(app, ["submit", "x"])
+    assert result.exit_code == 1
+    assert "job_id" in result.stderr
+
+
+def test_submit_with_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    sse_body = b"data: hello\n\ndata:  world\n\n: comment\n\n"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(200, json={"job_id": "s-1"})
+        assert request.url.path == "/v1/jobs/s-1/stream"
+        return httpx.Response(200, content=sse_body)
+
+    _install_transport(monkeypatch, handler)
+    result = runner.invoke(app, ["submit", "go", "--stream"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    out_lines = [ln for ln in result.stdout.splitlines() if ln]
+    assert "s-1" in out_lines
+    assert "hello" in out_lines
+    assert "world" in out_lines
+
+
+def test_submit_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_transport(
+        monkeypatch, lambda r: httpx.Response(500, text="boom")
+    )
+    result = runner.invoke(app, ["submit", "x"])
+    assert result.exit_code == 2
+    assert "HTTP 500" in result.stderr
+
+
+def test_submit_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("nope", request=request)
+
+    _install_transport(monkeypatch, handler)
+    result = runner.invoke(app, ["submit", "x"])
+    assert result.exit_code == 2
+    assert "request failed" in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# status                                                                      #
+# --------------------------------------------------------------------------- #
+def test_status_basic(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"job_id": "j-1", "status": "running"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/v1/jobs/j-1"
+        assert request.url.params.get("mode") is None
+        return httpx.Response(200, json=payload)
+
+    _install_transport(monkeypatch, handler)
+    result = runner.invoke(app, ["status", "j-1"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout) == payload
+
+
+def test_status_with_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params.get("mode") == "b"
+        return httpx.Response(200, json={"status": "ok"})
+
+    _install_transport(monkeypatch, handler)
+    result = runner.invoke(app, ["status", "j-1", "--mode", "b"])
+    assert result.exit_code == 0
+
+
+# --------------------------------------------------------------------------- #
+# stream                                                                      #
+# --------------------------------------------------------------------------- #
+def test_stream_prints_data_lines(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = b"data: one\n\ndata:two\n\n\ndata: three\n"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/jobs/j-2/stream"
+        return httpx.Response(200, content=body)
+
+    _install_transport(monkeypatch, handler)
+    result = runner.invoke(app, ["stream", "j-2"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    lines = [ln for ln in result.stdout.splitlines() if ln]
+    assert lines == ["one", "two", "three"]
+
+
+def test_stream_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_transport(monkeypatch, lambda r: httpx.Response(404, text="missing"))
+    result = runner.invoke(app, ["stream", "nope"])
+    assert result.exit_code == 2
+    assert "HTTP 404" in result.stderr
+
+
+def test_stream_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("down", request=request)
+
+    _install_transport(monkeypatch, handler)
+    result = runner.invoke(app, ["stream", "j"])
+    assert result.exit_code == 2
+    assert "stream failed" in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# cancel                                                                      #
+# --------------------------------------------------------------------------- #
+def test_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/v1/jobs/abc/cancel"
+        return httpx.Response(200, json={"ok": True})
+
+    _install_transport(monkeypatch, handler)
+    result = runner.invoke(app, ["cancel", "abc"])
+    assert result.exit_code == 0
+    assert "cancelled abc" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# models                                                                      #
+# --------------------------------------------------------------------------- #
+def test_models_lists_data_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = {"data": [{"id": "m1"}, {"id": "m2"}]}
+    _install_transport(monkeypatch, lambda r: httpx.Response(200, json=body))
+    result = runner.invoke(app, ["models"])
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == ["m1", "m2"]
+
+
+def test_models_lists_models_field_with_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = {"models": [{"name": "alpha"}, {"name": "beta"}]}
+    _install_transport(monkeypatch, lambda r: httpx.Response(200, json=body))
+    result = runner.invoke(app, ["models"])
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == ["alpha", "beta"]
+
+
+def test_models_accepts_plain_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_transport(monkeypatch, lambda r: httpx.Response(200, json=["x", "y"]))
+    result = runner.invoke(app, ["models"])
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == ["x", "y"]
+
+
+def test_models_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_transport(monkeypatch, lambda r: httpx.Response(200, json={"data": []}))
+    result = runner.invoke(app, ["models"])
+    assert result.exit_code == 0
+    assert "(no models)" in result.stdout

--- a/tests/interfaces/test_cli_app.py
+++ b/tests/interfaces/test_cli_app.py
@@ -18,7 +18,7 @@ from orchestrator.interfaces.cli import (
     app,
 )
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #19

## Summary
Adds the typer-based `orchestrator` console script as a thin client of the local HTTP API. The console entry point in `pyproject.toml` is now `orchestrator.interfaces.cli:app`.

## Acceptance Criteria met
- [x] Built with `typer`.
- [x] Subcommands: `serve`, `mcp`, `submit`, `status`, `stream`, `cancel`, `models`.
- [x] `orchestrator serve` lazily delegates to `orchestrator.interfaces.server.run`.
- [x] `orchestrator mcp` lazily delegates to `orchestrator.interfaces.mcp_server.run`.
- [x] `orchestrator submit "msg" [--model X] [--stream]` POSTs `/v1/jobs`, prints `job_id`, optionally tails SSE.
- [x] `orchestrator status <job_id> [--mode a|b|c]` GETs `/v1/jobs/{id}` and prints the JSON payload.
- [x] `orchestrator stream <job_id>` tails the SSE stream and prints `data:` payloads.
- [x] `orchestrator cancel <job_id>` POSTs `/v1/jobs/{id}/cancel`.
- [x] `orchestrator models` lists `/v1/models`.
- [x] `--base-url` flag and `ORCHESTRATOR_URL` env honored (default `http://127.0.0.1:8000`).
- [x] `[project.scripts] orchestrator = "orchestrator.interfaces.cli:app"`.
- [x] Tests run typer's `CliRunner` against an `httpx.MockTransport` stub HTTP server.

## Quality gates
- ruff clean
- 301 passed / 1 skipped
- coverage 98.78% (new module 99%, fail-under 95%)
