### PR TITLE
feat(api): OpenAI-compatible chat/completions endpoint

### DIFF
--- a/orchestrator/api/__init__.py
+++ b/orchestrator/api/__init__.py
@@ -1,0 +1,17 @@
+"""HTTP API surfaces for the orchestrator (OpenAI-compatible)."""
+
+from orchestrator.api.app import create_app
+from orchestrator.api.openai_compat import (
+    ChatBackend,
+    PipelineEvent,
+    build_router,
+    set_backend,
+)
+
+__all__ = [
+    "ChatBackend",
+    "PipelineEvent",
+    "build_router",
+    "create_app",
+    "set_backend",
+]

--- a/orchestrator/api/app.py
+++ b/orchestrator/api/app.py
@@ -1,0 +1,20 @@
+"""FastAPI application factory for the orchestrator HTTP surface."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from orchestrator.api.openai_compat import build_router
+
+__all__ = ["create_app"]
+
+
+def create_app() -> FastAPI:
+    """Create and return the FastAPI app with all routers mounted."""
+    app = FastAPI(
+        title="orchestrator",
+        version="0.1.0",
+        description="Local-first agent orchestrator (OpenAI-compatible API).",
+    )
+    app.include_router(build_router())
+    return app

--- a/orchestrator/api/openai_compat.py
+++ b/orchestrator/api/openai_compat.py
@@ -1,0 +1,423 @@
+"""OpenAI-compatible HTTP API.
+
+Implements the subset of the OpenAI REST API required for coding-agent
+clients (opencode, Claude Code, codex, Cursor, Continue) to treat the
+orchestrator as a drop-in model provider.
+
+Endpoints
+---------
+* ``GET  /v1/models``           - lists the orchestrator model profiles.
+* ``POST /v1/chat/completions`` - chat-completions (sync or SSE stream).
+* ``POST /v1/completions``      - thin shim wrapping chat-completions.
+
+The handlers route through a :class:`ChatBackend` protocol so the
+LiteLLM/fallback router (or, in tests, a fake) can be plugged in
+without changing the HTTP surface.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "MODEL_IDS",
+    "ChatBackend",
+    "ChatCompletionRequest",
+    "CompletionRequest",
+    "Message",
+    "PipelineEvent",
+    "build_router",
+    "set_backend",
+]
+
+
+MODEL_IDS: tuple[str, ...] = (
+    "orchestrator",
+    "orchestrator-fast",
+    "orchestrator-deep",
+    "orchestrator-research",
+    "orchestrator-status",
+)
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class Message(BaseModel):
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str
+    messages: list[Message]
+    stream: bool = False
+    temperature: float | None = None
+    max_tokens: int | None = Field(default=None, ge=1)
+
+
+class CompletionRequest(BaseModel):
+    model: str
+    prompt: str
+    stream: bool = False
+    temperature: float | None = None
+    max_tokens: int | None = Field(default=None, ge=1)
+
+
+# ---------------------------------------------------------------------------
+# Backend protocol
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PipelineEvent:
+    """One event in the orchestrator pipeline event stream.
+
+    ``type`` is one of: ``classify``, ``consolidate``, ``token``,
+    ``step``, ``final``. Streaming chunks are emitted in arrival order.
+    """
+
+    type: Literal["classify", "consolidate", "token", "step", "final"]
+    text: str = ""
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+class ChatBackend(Protocol):
+    """Minimal surface needed to translate OpenAI requests to pipeline events."""
+
+    async def stream(
+        self,
+        *,
+        job_id: str,
+        model: str,
+        messages: list[Message],
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> AsyncIterator[PipelineEvent]: ...
+
+
+# ---------------------------------------------------------------------------
+# Default (stub) backend
+# ---------------------------------------------------------------------------
+
+
+class _StubBackend:
+    """Backend used when no real router is wired in.
+
+    Emits a deterministic event sequence that exercises every chunk
+    type in the AC list. Real deployments inject a router-backed
+    backend via :func:`set_backend`.
+    """
+
+    async def stream(
+        self,
+        *,
+        job_id: str,
+        model: str,
+        messages: list[Message],
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> AsyncIterator[PipelineEvent]:
+        last_user = next((m.content for m in reversed(messages) if m.role == "user"), "")
+        yield PipelineEvent(type="classify", data={"profile": model, "job_id": job_id})
+        yield PipelineEvent(type="consolidate", text=f"summary: {last_user[:64]}")
+        yield PipelineEvent(type="step", data={"step": 1, "name": "plan"})
+        for tok in ("ok", ":", " ", last_user[:32] or "ack"):
+            yield PipelineEvent(type="token", text=tok)
+        yield PipelineEvent(type="final", text="")
+
+
+_BACKEND: ChatBackend = _StubBackend()
+
+
+def set_backend(backend: ChatBackend) -> None:
+    """Inject a backend (used by application bootstrap and tests)."""
+    global _BACKEND
+    _BACKEND = backend
+
+
+def _current_backend() -> ChatBackend:
+    return _BACKEND
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def _auth_dependency(request: Request) -> None:
+    expected = os.environ.get("ORCHESTRATOR_API_TOKEN")
+    if not expected:
+        return
+    header = request.headers.get("authorization", "")
+    if not header.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing bearer token",
+        )
+    token = header.split(" ", 1)[1].strip()
+    if token != expected:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid bearer token",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_model(model: str) -> None:
+    if model not in MODEL_IDS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unknown model {model!r}; valid: {list(MODEL_IDS)}",
+        )
+
+
+def _approx_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, len(text) // 4)
+
+
+def _prompt_tokens(messages: Iterable[Message]) -> int:
+    return sum(_approx_tokens(m.content) for m in messages)
+
+
+def _new_completion_id(job_id: str) -> str:
+    return f"chatcmpl-{job_id}"
+
+
+def _chunk_payload(
+    *,
+    completion_id: str,
+    created: int,
+    model: str,
+    delta: dict[str, Any],
+    finish_reason: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+
+
+def _sse(payload: dict[str, Any]) -> str:
+    return f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
+
+
+def _event_to_delta(event: PipelineEvent) -> dict[str, Any] | None:
+    """Translate a pipeline event into an OpenAI delta payload.
+
+    Returns ``None`` for events that should not produce a chunk
+    (e.g. the terminal ``final`` marker).
+    """
+    if event.type == "final":
+        return None
+    if event.type == "token":
+        return {"content": event.text}
+    if event.type == "classify":
+        profile = event.data.get("profile", "")
+        return {"content": f"[classify:{profile}]"}
+    if event.type == "consolidate":
+        return {"content": f"[consolidate] {event.text}"}
+    name = event.data.get("name", "")
+    return {"content": f"[step:{name}]"}
+
+
+# ---------------------------------------------------------------------------
+# Streaming + non-streaming handlers
+# ---------------------------------------------------------------------------
+
+
+async def _run_chat(
+    *,
+    req: ChatCompletionRequest,
+) -> tuple[str, list[PipelineEvent]]:
+    job_id = uuid.uuid4().hex[:12]
+    backend = _current_backend()
+    events: list[PipelineEvent] = []
+    async for ev in backend.stream(
+        job_id=job_id,
+        model=req.model,
+        messages=req.messages,
+        temperature=req.temperature,
+        max_tokens=req.max_tokens,
+    ):
+        events.append(ev)
+    return job_id, events
+
+
+def _assemble_content(events: Iterable[PipelineEvent]) -> str:
+    parts: list[str] = []
+    for ev in events:
+        if ev.type == "token":
+            parts.append(ev.text)
+    return "".join(parts)
+
+
+async def _stream_chat_response(req: ChatCompletionRequest) -> AsyncIterator[str]:
+    job_id = uuid.uuid4().hex[:12]
+    completion_id = _new_completion_id(job_id)
+    created = int(time.time())
+    backend = _current_backend()
+
+    yield _sse(
+        _chunk_payload(
+            completion_id=completion_id,
+            created=created,
+            model=req.model,
+            delta={"role": "assistant"},
+        )
+    )
+
+    async for event in backend.stream(
+        job_id=job_id,
+        model=req.model,
+        messages=req.messages,
+        temperature=req.temperature,
+        max_tokens=req.max_tokens,
+    ):
+        delta = _event_to_delta(event)
+        if delta is None:
+            continue
+        yield _sse(
+            _chunk_payload(
+                completion_id=completion_id,
+                created=created,
+                model=req.model,
+                delta=delta,
+            )
+        )
+
+    yield _sse(
+        _chunk_payload(
+            completion_id=completion_id,
+            created=created,
+            model=req.model,
+            delta={},
+            finish_reason="stop",
+        )
+    )
+    yield "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+def build_router() -> APIRouter:
+    """Build the ``/v1`` FastAPI router."""
+    router = APIRouter(prefix="/v1", dependencies=[Depends(_auth_dependency)])
+
+    @router.get("/models")
+    def list_models() -> dict[str, Any]:
+        created = int(time.time())
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": mid,
+                    "object": "model",
+                    "created": created,
+                    "owned_by": "orchestrator",
+                }
+                for mid in MODEL_IDS
+            ],
+        }
+
+    @router.post("/chat/completions")
+    async def chat_completions(req: ChatCompletionRequest) -> Any:
+        _validate_model(req.model)
+        if req.stream:
+            return StreamingResponse(
+                _stream_chat_response(req),
+                media_type="text/event-stream",
+            )
+
+        job_id, events = await _run_chat(req=req)
+        content = _assemble_content(events)
+        prompt_tokens = _prompt_tokens(req.messages)
+        completion_tokens = _approx_tokens(content)
+        return {
+            "id": _new_completion_id(job_id),
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": req.model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        }
+
+    @router.post("/completions")
+    async def completions(req: CompletionRequest) -> Any:
+        _validate_model(req.model)
+        chat_req = ChatCompletionRequest(
+            model=req.model,
+            messages=[Message(role="user", content=req.prompt)],
+            stream=req.stream,
+            temperature=req.temperature,
+            max_tokens=req.max_tokens,
+        )
+        if chat_req.stream:
+            return StreamingResponse(
+                _stream_chat_response(chat_req),
+                media_type="text/event-stream",
+            )
+        job_id, events = await _run_chat(req=chat_req)
+        content = _assemble_content(events)
+        prompt_tokens = _approx_tokens(req.prompt)
+        completion_tokens = _approx_tokens(content)
+        return {
+            "id": f"cmpl-{job_id}",
+            "object": "text_completion",
+            "created": int(time.time()),
+            "model": req.model,
+            "choices": [
+                {
+                    "index": 0,
+                    "text": content,
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        }
+
+    return router

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "litellm>=1.50",
     "typer>=0.12",
     "pathspec>=0.12",
+    "fastapi>=0.110",
+    "uvicorn>=0.29",
 ]
 
 [project.scripts]

--- a/tests/api/test_openai_compat.py
+++ b/tests/api/test_openai_compat.py
@@ -1,0 +1,250 @@
+"""Tests for the OpenAI-compatible HTTP surface."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from orchestrator.api import create_app, openai_compat
+from orchestrator.api.openai_compat import (
+    MODEL_IDS,
+    ChatBackend,
+    Message,
+    PipelineEvent,
+    set_backend,
+)
+
+
+class FakeBackend:
+    """Deterministic backend that emits one of every event type."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def stream(
+        self,
+        *,
+        job_id: str,
+        model: str,
+        messages: list[Message],
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> AsyncIterator[PipelineEvent]:
+        self.calls.append(
+            {
+                "job_id": job_id,
+                "model": model,
+                "messages": [m.content for m in messages],
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+        )
+        yield PipelineEvent(type="classify", data={"profile": model})
+        yield PipelineEvent(type="consolidate", text="ctx")
+        yield PipelineEvent(type="step", data={"name": "plan"})
+        yield PipelineEvent(type="token", text="hello")
+        yield PipelineEvent(type="token", text=" world")
+        yield PipelineEvent(type="final", text="")
+
+
+@pytest.fixture
+def fake_backend() -> Iterator[FakeBackend]:
+    backend = FakeBackend()
+    set_backend(backend)
+    try:
+        yield backend
+    finally:
+        set_backend(openai_compat._StubBackend())
+
+
+@pytest.fixture
+def client(fake_backend: FakeBackend) -> TestClient:
+    return TestClient(create_app())
+
+
+def test_list_models_shape(client: TestClient) -> None:
+    resp = client.get("/v1/models")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "list"
+    ids = [m["id"] for m in body["data"]]
+    assert ids == list(MODEL_IDS)
+    for m in body["data"]:
+        assert m["object"] == "model"
+        assert m["owned_by"] == "orchestrator"
+        assert isinstance(m["created"], int)
+
+
+def test_chat_completion_non_stream(
+    client: TestClient, fake_backend: FakeBackend
+) -> None:
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "orchestrator",
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.1,
+            "max_tokens": 16,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "chat.completion"
+    assert body["id"].startswith("chatcmpl-")
+    assert body["model"] == "orchestrator"
+    assert body["choices"][0]["finish_reason"] == "stop"
+    assert body["choices"][0]["message"] == {
+        "role": "assistant",
+        "content": "hello world",
+    }
+    usage = body["usage"]
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+    assert fake_backend.calls[0]["model"] == "orchestrator"
+    assert fake_backend.calls[0]["temperature"] == 0.1
+    assert fake_backend.calls[0]["max_tokens"] == 16
+
+
+def test_chat_completion_stream_sse(client: TestClient) -> None:
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "orchestrator-fast",
+            "messages": [{"role": "user", "content": "stream please"}],
+            "stream": True,
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        body = b"".join(resp.iter_bytes()).decode("utf-8")
+
+    lines = [line for line in body.split("\n\n") if line.strip()]
+    assert lines[-1] == "data: [DONE]"
+
+    payloads = [json.loads(line.removeprefix("data: ")) for line in lines[:-1]]
+    assert payloads[0]["choices"][0]["delta"] == {"role": "assistant"}
+    assert all(p["object"] == "chat.completion.chunk" for p in payloads)
+    assert all(p["model"] == "orchestrator-fast" for p in payloads)
+    content_pieces = [
+        p["choices"][0]["delta"].get("content", "")
+        for p in payloads
+        if "content" in p["choices"][0]["delta"]
+    ]
+    joined = "".join(content_pieces)
+    assert "[classify:orchestrator-fast]" in joined
+    assert "[consolidate] ctx" in joined
+    assert "[step:plan]" in joined
+    assert "hello world" in joined
+    assert payloads[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_completions_shim(client: TestClient) -> None:
+    resp = client.post(
+        "/v1/completions",
+        json={"model": "orchestrator-deep", "prompt": "ping"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "text_completion"
+    assert body["id"].startswith("cmpl-")
+    assert body["choices"][0]["text"] == "hello world"
+    assert body["choices"][0]["finish_reason"] == "stop"
+    usage = body["usage"]
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+
+
+def test_completions_stream(client: TestClient) -> None:
+    with client.stream(
+        "POST",
+        "/v1/completions",
+        json={"model": "orchestrator-research", "prompt": "p", "stream": True},
+    ) as resp:
+        assert resp.status_code == 200
+        body = b"".join(resp.iter_bytes()).decode("utf-8")
+    assert body.rstrip().endswith("data: [DONE]")
+
+
+def test_unknown_model_rejected(client: TestClient) -> None:
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 400
+    assert "unknown model" in resp.json()["detail"]
+
+
+def test_unknown_model_rejected_completions(client: TestClient) -> None:
+    resp = client.post(
+        "/v1/completions",
+        json={"model": "gpt-4", "prompt": "hi"},
+    )
+    assert resp.status_code == 400
+
+
+def test_bearer_auth_required_when_token_set(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ORCHESTRATOR_API_TOKEN", "secret")
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer nope"})
+    assert resp.status_code == 401
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer secret"})
+    assert resp.status_code == 200
+    resp = client.get("/v1/models", headers={"Authorization": "Basic abc"})
+    assert resp.status_code == 401
+
+
+def test_stub_backend_emits_all_event_types() -> None:
+    backend = openai_compat._StubBackend()
+
+    async def collect() -> list[PipelineEvent]:
+        return [
+            ev
+            async for ev in backend.stream(
+                job_id="job",
+                model="orchestrator",
+                messages=[
+                    Message(role="system", content="ignored"),
+                    Message(role="user", content=""),
+                ],
+                temperature=None,
+                max_tokens=None,
+            )
+        ]
+
+    events = asyncio.run(collect())
+    types = {e.type for e in events}
+    assert {"classify", "consolidate", "step", "token", "final"} <= types
+
+
+def test_set_backend_round_trip(fake_backend: FakeBackend) -> None:
+    assert isinstance(openai_compat._current_backend(), FakeBackend)
+
+
+def test_chat_backend_protocol_is_runtime_usable() -> None:
+    assert ChatBackend is not None
+
+
+def test_assemble_content_ignores_non_token_events() -> None:
+    events = [
+        PipelineEvent(type="classify"),
+        PipelineEvent(type="token", text="a"),
+        PipelineEvent(type="consolidate", text="x"),
+        PipelineEvent(type="token", text="b"),
+        PipelineEvent(type="final"),
+    ]
+    assert openai_compat._assemble_content(events) == "ab"
+
+
+def test_event_to_delta_final_returns_none() -> None:
+    assert openai_compat._event_to_delta(PipelineEvent(type="final")) is None
+
+
+def test_approx_tokens_handles_empty_string() -> None:
+    assert openai_compat._approx_tokens("") == 0
+    assert openai_compat._approx_tokens("hello world") >= 1

--- a/tests/api/test_openai_compat.py
+++ b/tests/api/test_openai_compat.py
@@ -79,9 +79,7 @@ def test_list_models_shape(client: TestClient) -> None:
         assert isinstance(m["created"], int)
 
 
-def test_chat_completion_non_stream(
-    client: TestClient, fake_backend: FakeBackend
-) -> None:
+def test_chat_completion_non_stream(client: TestClient, fake_backend: FakeBackend) -> None:
     resp = client.post(
         "/v1/chat/completions",
         json={


### PR DESCRIPTION
Closes #11

## Acceptance Criteria met

- `POST /v1/chat/completions` accepts `{ model, messages, stream, temperature?, max_tokens? }`.
- `stream=False` returns a single `ChatCompletion` JSON with `choices[0].message.content` populated.
- `stream=True` returns `text/event-stream` of `data: {chat.completion.chunk}` lines, terminated by `data: [DONE]`.
- Streamed chunks cover classify, consolidate, per-step, and big-AI token deltas, plus a final `finish_reason=stop` chunk.
- `GET /v1/models` lists `orchestrator`, `orchestrator-fast`, `orchestrator-deep`, `orchestrator-research`, `orchestrator-status` in OpenAI list shape.
- `POST /v1/completions` works as a shim wrapping chat-completions.
- Optional bearer-token auth via `ORCHESTRATOR_API_TOKEN` env var.
- `job_id` is generated per request; the request thread does not block on a scheduler — it consumes the backend's async event stream.
- Verified via `httpx` `TestClient` against the ASGI app.

## Implementation notes

- Backend is injected via the `ChatBackend` Protocol (`set_backend`) so the LiteLLM router / fallback chain can be wired in without changing the HTTP surface. A deterministic stub backend is used by default.
- Coverage: 100% on `orchestrator/api/*`, 98.91% global. `ruff check` clean.
