### PR TITLE
feat(api): native task HTTP API

### DIFF
--- a/orchestrator/api/app.py
+++ b/orchestrator/api/app.py
@@ -1,10 +1,9 @@
-"""FastAPI application factory for the orchestrator HTTP surface."""
-"""FastAPI app composition for orchestrator HTTP interfaces.
+"""FastAPI application factory for the orchestrator HTTP surface.
 
 This module is intentionally small. Other interface routers (e.g. the
-OpenAI-compatible router from #11) mount themselves here too; keep
-edits idempotent and additive so the routers can be merged without
-conflict.
+OpenAI-compatible router from #11, native task API from #15) mount
+themselves here too; keep edits idempotent and additive so the routers
+can be merged without conflict.
 """
 
 from __future__ import annotations
@@ -12,8 +11,9 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from orchestrator.api.openai_compat import build_router
+from orchestrator.api.tasks import router as tasks_router
 
-__all__ = ["create_app"]
+__all__ = ["app", "create_app"]
 
 
 def create_app() -> FastAPI:
@@ -24,8 +24,8 @@ def create_app() -> FastAPI:
         description="Local-first agent orchestrator (OpenAI-compatible API).",
     )
     app.include_router(build_router())
+    app.include_router(tasks_router)
     return app
-from orchestrator.api.tasks import router as tasks_router
 
-app = FastAPI(title="orchestrator")
-app.include_router(tasks_router)
+
+app = create_app()

--- a/orchestrator/api/app.py
+++ b/orchestrator/api/app.py
@@ -1,4 +1,11 @@
 """FastAPI application factory for the orchestrator HTTP surface."""
+"""FastAPI app composition for orchestrator HTTP interfaces.
+
+This module is intentionally small. Other interface routers (e.g. the
+OpenAI-compatible router from #11) mount themselves here too; keep
+edits idempotent and additive so the routers can be merged without
+conflict.
+"""
 
 from __future__ import annotations
 
@@ -18,3 +25,7 @@ def create_app() -> FastAPI:
     )
     app.include_router(build_router())
     return app
+from orchestrator.api.tasks import router as tasks_router
+
+app = FastAPI(title="orchestrator")
+app.include_router(tasks_router)

--- a/orchestrator/api/tasks.py
+++ b/orchestrator/api/tasks.py
@@ -1,0 +1,323 @@
+"""Native FastAPI router for the orchestrator (issue #15).
+
+Exposes explicit job IDs, mid-flight status queries with three modes,
+SSE streams, and cooperative cancellation. Job submission is
+non-blocking: the handler enqueues the job and returns its ID before
+any pipeline work happens.
+
+The module ships an in-process :class:`JobManager` that owns job
+lifecycle, event fan-out, and cancellation. Production deployments
+inject a manager wired to the real scheduler / state-store / recovery
+modules via :func:`set_job_manager`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "Job",
+    "JobManager",
+    "JobStatus",
+    "PipelineEvent",
+    "PipelineRunner",
+    "get_job_manager",
+    "router",
+    "set_job_manager",
+]
+
+
+class JobStatus(str, Enum):  # noqa: UP042 - explicit str inheritance for FastAPI/JSON
+    """Lifecycle states for a submitted job."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+_TERMINAL: frozenset[JobStatus] = frozenset(
+    {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
+)
+
+
+@dataclass
+class PipelineEvent:
+    """A single event emitted by the pipeline for a job."""
+
+    kind: str
+    data: dict[str, Any]
+    ts: float = field(default_factory=time.time)
+
+
+@dataclass
+class Job:
+    """In-memory job state. Mirrors what ``GET /jobs/{id}`` returns."""
+
+    id: str
+    user_msg: str
+    model: str | None
+    status: JobStatus = JobStatus.QUEUED
+    job_class: str | None = None
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
+    final_output: str | None = None
+    error: str | None = None
+    cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
+    events: list[PipelineEvent] = field(default_factory=list)
+    subscribers: list[asyncio.Queue[PipelineEvent | None]] = field(default_factory=list)
+
+    def to_state(self) -> dict[str, Any]:
+        """Serialise the public job state for ``GET /jobs/{id}``."""
+        return {
+            "id": self.id,
+            "status": self.status.value,
+            "class": self.job_class,
+            "steps": list(self.steps),
+            "artifacts": list(self.artifacts),
+            "final_output": self.final_output,
+            "error": self.error,
+        }
+
+
+PipelineRunner = Callable[[Job, "JobManager"], Awaitable[None]]
+
+
+async def _default_runner(job: Job, mgr: JobManager) -> None:
+    """Trivial pipeline used when no runner is injected.
+
+    Emits ``started`` -> one ``step`` -> ``completed``. Real deployments
+    inject a runner that drives the scheduler, state-store and recovery
+    modules.
+    """
+    job.job_class = "default"
+    await mgr.emit(job, "started", {"user_msg": job.user_msg, "model": job.model})
+    if job.cancel_event.is_set():  # pragma: no cover - cooperative early exit
+        return
+    job.steps.append({"name": "echo", "ok": True})
+    await mgr.emit(job, "step", {"name": "echo"})
+    job.final_output = job.user_msg
+    await mgr.emit(job, "completed", {})
+
+
+class JobManager:
+    """Owns job lifecycle, event fan-out, and cancellation."""
+
+    def __init__(self, runner: PipelineRunner | None = None) -> None:
+        self._jobs: dict[str, Job] = {}
+        self._runner: PipelineRunner = runner or _default_runner
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+
+    def get(self, job_id: str) -> Job:
+        """Look up a job, raising 404 if unknown."""
+        try:
+            return self._jobs[job_id]
+        except KeyError as exc:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="unknown job_id") from exc
+
+    def submit(self, user_msg: str, model: str | None) -> Job:
+        """Enqueue a new job and schedule its runner. Non-blocking."""
+        job = Job(id=uuid.uuid4().hex, user_msg=user_msg, model=model)
+        self._jobs[job.id] = job
+        self._tasks[job.id] = asyncio.create_task(self._run(job))
+        return job
+
+    async def _run(self, job: Job) -> None:
+        job.status = JobStatus.RUNNING
+        try:
+            await self._runner(job, self)
+        except asyncio.CancelledError:
+            job.status = JobStatus.CANCELLED
+            await self.emit(job, "cancelled", {}, mark_terminal=True)
+            raise
+        except Exception as exc:
+            job.status = JobStatus.FAILED
+            job.error = repr(exc)
+            await self.emit(job, "failed", {"error": repr(exc)}, mark_terminal=True)
+            return
+        if job.status == JobStatus.RUNNING:
+            job.status = JobStatus.COMPLETED
+        await self._close_subscribers(job)
+
+    async def emit(
+        self,
+        job: Job,
+        kind: str,
+        data: dict[str, Any],
+        *,
+        mark_terminal: bool = False,
+    ) -> None:
+        """Append a pipeline event and fan it out to live subscribers."""
+        ev = PipelineEvent(kind=kind, data=data)
+        job.events.append(ev)
+        for q in list(job.subscribers):
+            await q.put(ev)
+        if mark_terminal:
+            await self._close_subscribers(job)
+
+    async def _close_subscribers(self, job: Job) -> None:
+        for q in list(job.subscribers):
+            await q.put(None)
+        job.subscribers.clear()
+
+    async def cancel(self, job: Job) -> None:
+        """Cooperatively cancel a job. No-op if already terminal."""
+        if job.status in _TERMINAL:
+            return
+        job.cancel_event.set()
+        task = self._tasks.get(job.id)
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        if job.status not in _TERMINAL:
+            job.status = JobStatus.CANCELLED
+            await self._close_subscribers(job)
+
+    def status_payload(self, job: Job, mode: str) -> dict[str, Any]:
+        """Return the payload for ``POST /jobs/{id}/status``.
+
+        Modes mirror the three orchestrator status modes:
+
+        * ``a`` - instant DB-template snapshot (cheapest).
+        * ``b`` - 1.5B narrator gloss over current state.
+        * ``c`` - full reasoning synthesis (heaviest).
+        """
+        if mode == "a":
+            return {
+                "mode": "a",
+                "status": job.status.value,
+                "steps_done": len(job.steps),
+                "class": job.job_class,
+            }
+        if mode == "b":
+            last = job.events[-1].kind if job.events else "idle"
+            return {
+                "mode": "b",
+                "status": job.status.value,
+                "narration": f"job {job.id} is {job.status.value}; last event={last}",
+            }
+        if mode == "c":
+            return {
+                "mode": "c",
+                "status": job.status.value,
+                "class": job.job_class,
+                "steps": list(job.steps),
+                "artifacts": list(job.artifacts),
+                "final_output": job.final_output,
+                "reasoning": [e.kind for e in job.events],
+            }
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="mode must be one of 'a', 'b', 'c'",
+        )
+
+    async def stream(self, job: Job) -> AsyncIterator[PipelineEvent]:
+        """Yield pipeline events for a job until terminal."""
+        q: asyncio.Queue[PipelineEvent | None] = asyncio.Queue()
+        for ev in job.events:
+            await q.put(ev)
+        if job.status in _TERMINAL:
+            await q.put(None)
+        else:
+            job.subscribers.append(q)
+        try:
+            while True:
+                ev = await q.get()
+                if ev is None:
+                    return
+                yield ev
+        finally:
+            if q in job.subscribers:
+                job.subscribers.remove(q)
+
+
+_manager: JobManager | None = None
+
+
+def get_job_manager() -> JobManager:
+    """Return the process-wide :class:`JobManager`, creating one lazily."""
+    global _manager
+    if _manager is None:
+        _manager = JobManager()
+    return _manager
+
+
+def set_job_manager(mgr: JobManager | None) -> None:
+    """Install (or clear) the process-wide :class:`JobManager`. Test hook."""
+    global _manager
+    _manager = mgr
+
+
+router = APIRouter(tags=["jobs"])
+
+
+class JobSubmit(BaseModel):
+    """Body for ``POST /jobs``."""
+
+    user_msg: str = Field(..., min_length=1)
+    model: str | None = None
+
+
+class StatusRequest(BaseModel):
+    """Body for ``POST /jobs/{id}/status``."""
+
+    mode: Literal["a", "b", "c"]
+
+
+@router.post("/jobs", status_code=status.HTTP_202_ACCEPTED)
+async def submit_job(payload: JobSubmit) -> dict[str, str]:
+    """Enqueue a job and return its id immediately."""
+    mgr = get_job_manager()
+    job = mgr.submit(payload.user_msg, payload.model)
+    return {"job_id": job.id}
+
+
+@router.get("/jobs/{job_id}")
+async def get_job(job_id: str) -> dict[str, Any]:
+    """Return the full job state."""
+    return get_job_manager().get(job_id).to_state()
+
+
+@router.get("/jobs/{job_id}/stream")
+async def stream_job(job_id: str) -> StreamingResponse:
+    """SSE stream of pipeline events for the job."""
+    mgr = get_job_manager()
+    job = mgr.get(job_id)
+
+    async def gen() -> AsyncIterator[bytes]:
+        async for ev in mgr.stream(job):
+            payload = json.dumps(ev.data, default=str)
+            yield f"event: {ev.kind}\ndata: {payload}\n\n".encode()
+
+    return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+@router.post("/jobs/{job_id}/status")
+async def job_status(job_id: str, payload: StatusRequest) -> dict[str, Any]:
+    """Return a status payload in mode ``a``, ``b`` or ``c``."""
+    mgr = get_job_manager()
+    job = mgr.get(job_id)
+    return mgr.status_payload(job, payload.mode)
+
+
+@router.post("/jobs/{job_id}/cancel", status_code=status.HTTP_202_ACCEPTED)
+async def cancel_job(job_id: str) -> dict[str, str]:
+    """Cooperatively cancel a running job."""
+    mgr = get_job_manager()
+    job = mgr.get(job_id)
+    await mgr.cancel(job)
+    return {"job_id": job.id, "status": job.status.value}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "pathspec>=0.12",
     "fastapi>=0.110",
     "uvicorn>=0.29",
+    "fastapi>=0.110",
+    "starlette>=0.37",
 ]
 
 [project.scripts]

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -41,8 +41,13 @@ def client() -> TestClient:
 
 def test_app_mounts_native_router() -> None:
     paths = {route.path for route in app_module.app.router.routes}
-    assert {"/jobs", "/jobs/{job_id}", "/jobs/{job_id}/stream",
-            "/jobs/{job_id}/status", "/jobs/{job_id}/cancel"} <= paths
+    assert {
+        "/jobs",
+        "/jobs/{job_id}",
+        "/jobs/{job_id}/stream",
+        "/jobs/{job_id}/status",
+        "/jobs/{job_id}/cancel",
+    } <= paths
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -1,0 +1,344 @@
+"""Tests for the native job HTTP API (issue #15)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from orchestrator.api import app as app_module
+from orchestrator.api import tasks as tasks_module
+from orchestrator.api.tasks import (
+    Job,
+    JobManager,
+    JobStatus,
+    PipelineEvent,
+    get_job_manager,
+    set_job_manager,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_manager() -> AsyncIterator[None]:
+    set_job_manager(None)
+    yield
+    set_job_manager(None)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app_module.app)
+
+
+# ---------------------------------------------------------------------------
+# router composition
+# ---------------------------------------------------------------------------
+
+
+def test_app_mounts_native_router() -> None:
+    paths = {route.path for route in app_module.app.router.routes}
+    assert {"/jobs", "/jobs/{job_id}", "/jobs/{job_id}/stream",
+            "/jobs/{job_id}/status", "/jobs/{job_id}/cancel"} <= paths
+
+
+# ---------------------------------------------------------------------------
+# POST /jobs
+# ---------------------------------------------------------------------------
+
+
+def test_submit_returns_202_with_job_id(client: TestClient) -> None:
+    async def quiet(job: Job, mgr: JobManager) -> None:
+        await mgr.emit(job, "started", {})
+        # leave running so we can observe queued/running state
+
+    set_job_manager(JobManager(runner=quiet))
+    resp = client.post("/jobs", json={"user_msg": "hello", "model": "m1"})
+    assert resp.status_code == 202
+    body = resp.json()
+    assert "job_id" in body and isinstance(body["job_id"], str)
+
+
+def test_submit_validates_empty_msg(client: TestClient) -> None:
+    resp = client.post("/jobs", json={"user_msg": ""})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /jobs/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_unknown_job_is_404(client: TestClient) -> None:
+    resp = client.get("/jobs/nope")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "unknown job_id"
+
+
+def test_get_returns_full_state(client: TestClient) -> None:
+    async def runner(job: Job, mgr: JobManager) -> None:
+        job.job_class = "qa"
+        job.steps.append({"name": "plan", "ok": True})
+        job.artifacts.append({"path": "out.md"})
+        await mgr.emit(job, "step", {"name": "plan"})
+        job.final_output = "answer"
+
+    set_job_manager(JobManager(runner=runner))
+    job_id = client.post("/jobs", json={"user_msg": "q"}).json()["job_id"]
+    # let the runner finish
+    for _ in range(20):
+        state = client.get(f"/jobs/{job_id}").json()
+        if state["status"] == "completed":
+            break
+    assert state["class"] == "qa"
+    assert state["steps"] == [{"name": "plan", "ok": True}]
+    assert state["artifacts"] == [{"path": "out.md"}]
+    assert state["final_output"] == "answer"
+    assert state["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# POST /jobs/{id}/status
+# ---------------------------------------------------------------------------
+
+
+def test_status_modes_a_b_c(client: TestClient) -> None:
+    async def runner(job: Job, mgr: JobManager) -> None:
+        job.job_class = "chat"
+        job.steps.append({"name": "s1"})
+        await mgr.emit(job, "step", {"name": "s1"})
+
+    set_job_manager(JobManager(runner=runner))
+    job_id = client.post("/jobs", json={"user_msg": "hi"}).json()["job_id"]
+    for _ in range(20):
+        if client.get(f"/jobs/{job_id}").json()["status"] == "completed":
+            break
+
+    a = client.post(f"/jobs/{job_id}/status", json={"mode": "a"}).json()
+    assert a == {"mode": "a", "status": "completed", "steps_done": 1, "class": "chat"}
+
+    b = client.post(f"/jobs/{job_id}/status", json={"mode": "b"}).json()
+    assert b["mode"] == "b" and "narration" in b and b["status"] == "completed"
+
+    c = client.post(f"/jobs/{job_id}/status", json={"mode": "c"}).json()
+    assert c["mode"] == "c"
+    assert c["steps"] == [{"name": "s1"}]
+    assert "step" in c["reasoning"]
+
+
+def test_status_invalid_mode_rejected_by_pydantic(client: TestClient) -> None:
+    set_job_manager(JobManager(runner=_noop_runner))
+    job_id = client.post("/jobs", json={"user_msg": "hi"}).json()["job_id"]
+    resp = client.post(f"/jobs/{job_id}/status", json={"mode": "z"})
+    assert resp.status_code == 422
+
+
+def test_status_invalid_mode_in_manager_raises_422() -> None:
+    mgr = JobManager()
+    job = Job(id="x", user_msg="m", model=None)
+    with pytest.raises(Exception) as ei:
+        mgr.status_payload(job, "z")
+    assert "422" in repr(ei.value) or "mode" in repr(ei.value)
+
+
+def test_status_mode_b_idle_when_no_events() -> None:
+    mgr = JobManager()
+    job = Job(id="x", user_msg="m", model=None)
+    payload = mgr.status_payload(job, "b")
+    assert "idle" in payload["narration"]
+
+
+def test_status_unknown_job_404(client: TestClient) -> None:
+    resp = client.post("/jobs/nope/status", json={"mode": "a"})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /jobs/{id}/cancel
+# ---------------------------------------------------------------------------
+
+
+async def _noop_runner(job: Job, mgr: JobManager) -> None:
+    await mgr.emit(job, "started", {})
+
+
+def test_cancel_unknown_404(client: TestClient) -> None:
+    resp = client.post("/jobs/nope/cancel")
+    assert resp.status_code == 404
+
+
+def test_cancel_running_job() -> None:
+    async def slow(job: Job, mgr: JobManager) -> None:
+        await mgr.emit(job, "started", {})
+        await asyncio.sleep(5)
+        await mgr.emit(job, "completed", {})  # pragma: no cover - cancelled first
+
+    async def scenario() -> dict[str, object]:
+        set_job_manager(JobManager(runner=slow))
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app_module.app), base_url="http://t"
+        ) as ac:
+            job_id = (await ac.post("/jobs", json={"user_msg": "x"})).json()["job_id"]
+            await asyncio.sleep(0.05)
+            resp = await ac.post(f"/jobs/{job_id}/cancel")
+            assert resp.status_code == 202
+            assert resp.json()["status"] == "cancelled"
+            state = (await ac.get(f"/jobs/{job_id}")).json()
+            return state
+
+    state = asyncio.run(scenario())
+    assert state["status"] == "cancelled"
+
+
+def test_cancel_terminal_is_noop() -> None:
+    async def runner(job: Job, mgr: JobManager) -> None:
+        await mgr.emit(job, "started", {})
+
+    async def scenario() -> str:
+        mgr = JobManager(runner=runner)
+        set_job_manager(mgr)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app_module.app), base_url="http://t"
+        ) as ac:
+            job_id = (await ac.post("/jobs", json={"user_msg": "x"})).json()["job_id"]
+            for _ in range(20):
+                state = (await ac.get(f"/jobs/{job_id}")).json()
+                if state["status"] == "completed":
+                    break
+                await asyncio.sleep(0.01)
+            resp = await ac.post(f"/jobs/{job_id}/cancel")
+            assert resp.status_code == 202
+            return resp.json()["status"]
+
+    assert asyncio.run(scenario()) == "completed"
+
+
+# ---------------------------------------------------------------------------
+# GET /jobs/{id}/stream  (SSE)
+# ---------------------------------------------------------------------------
+
+
+def test_stream_replays_events_for_terminal_job() -> None:
+    async def runner(job: Job, mgr: JobManager) -> None:
+        await mgr.emit(job, "started", {"x": 1})
+        await mgr.emit(job, "step", {"name": "s"})
+
+    async def scenario() -> list[str]:
+        set_job_manager(JobManager(runner=runner))
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app_module.app), base_url="http://t"
+        ) as ac:
+            job_id = (await ac.post("/jobs", json={"user_msg": "x"})).json()["job_id"]
+            for _ in range(20):
+                if (await ac.get(f"/jobs/{job_id}")).json()["status"] == "completed":
+                    break
+                await asyncio.sleep(0.01)
+            kinds: list[str] = []
+            async with ac.stream("GET", f"/jobs/{job_id}/stream") as resp:
+                assert resp.status_code == 200
+                assert resp.headers["content-type"].startswith("text/event-stream")
+                async for line in resp.aiter_lines():
+                    if line.startswith("event: "):
+                        kinds.append(line.removeprefix("event: "))
+            return kinds
+
+    kinds = asyncio.run(scenario())
+    assert "started" in kinds and "step" in kinds
+
+
+def test_stream_live_subscriber_receives_events() -> None:
+    started = asyncio.Event()
+    proceed = asyncio.Event()
+
+    async def runner(job: Job, mgr: JobManager) -> None:
+        await mgr.emit(job, "started", {})
+        started.set()
+        await asyncio.wait_for(proceed.wait(), timeout=2.0)
+        await mgr.emit(job, "done-step", {"k": "v"})
+
+    async def scenario() -> list[str]:
+        set_job_manager(JobManager(runner=runner))
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app_module.app), base_url="http://t"
+        ) as ac:
+            job_id = (await ac.post("/jobs", json={"user_msg": "x"})).json()["job_id"]
+            await started.wait()
+            kinds: list[str] = []
+
+            async def reader() -> None:
+                async with ac.stream("GET", f"/jobs/{job_id}/stream") as resp:
+                    async for line in resp.aiter_lines():
+                        if line.startswith("event: "):
+                            kinds.append(line.removeprefix("event: "))
+                        if line.startswith("data: "):
+                            json.loads(line.removeprefix("data: "))
+
+            reader_task = asyncio.create_task(reader())
+            await asyncio.sleep(0.05)
+            proceed.set()
+            await asyncio.wait_for(reader_task, timeout=2.0)
+            return kinds
+
+    kinds = asyncio.run(scenario())
+    assert "done-step" in kinds
+
+
+def test_stream_unknown_job_404(client: TestClient) -> None:
+    resp = client.get("/jobs/nope/stream")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# JobManager unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_runner_failure_marks_failed() -> None:
+    async def boom(job: Job, mgr: JobManager) -> None:
+        raise RuntimeError("kaboom")
+
+    async def scenario() -> dict[str, object]:
+        mgr = JobManager(runner=boom)
+        job = mgr.submit("x", None)
+        await asyncio.sleep(0.05)
+        return job.to_state()
+
+    state = asyncio.run(scenario())
+    assert state["status"] == "failed"
+    assert "kaboom" in str(state["error"])
+
+
+def test_get_job_manager_singleton() -> None:
+    set_job_manager(None)
+    a = get_job_manager()
+    b = get_job_manager()
+    assert a is b
+
+
+def test_default_runner_executes() -> None:
+    async def scenario() -> Job:
+        mgr = JobManager()  # uses _default_runner
+        job = mgr.submit("hi", "m")
+        for _ in range(30):
+            if job.status in {JobStatus.COMPLETED, JobStatus.FAILED}:
+                break
+            await asyncio.sleep(0.01)
+        return job
+
+    job = asyncio.run(scenario())
+    assert job.status == JobStatus.COMPLETED
+    assert job.final_output == "hi"
+    assert job.job_class == "default"
+
+
+def test_pipeline_event_defaults() -> None:
+    ev = PipelineEvent(kind="x", data={"a": 1})
+    assert ev.kind == "x" and ev.data == {"a": 1} and ev.ts > 0
+
+
+def test_module_exports() -> None:
+    assert hasattr(tasks_module, "router")
+    assert hasattr(tasks_module, "JobManager")


### PR DESCRIPTION
Closes #15

## Acceptance Criteria met

- [x] `POST /jobs` body `{user_msg, model?}` returns `202 {job_id}` immediately (non-blocking).
- [x] `GET /jobs/{id}` returns full job state JSON (status, class, steps, artifacts, final_output, error).
- [x] `GET /jobs/{id}/stream` emits SSE `event: <kind>\ndata: <json>\n\n` per pipeline event.
- [x] `POST /jobs/{id}/status` with mode `a`/`b`/`c` returns the matching status payload.
- [x] `POST /jobs/{id}/cancel` returns `202` and cooperatively cancels the job.
- [x] 404 on unknown `job_id` for every endpoint.
- [x] `orchestrator/api/app.py` composes the FastAPI app, mounting the native router additively so the OpenAI-compat router (#11) can be merged without conflict.
- [x] Tests cover all five endpoints + composition (FastAPI `TestClient` and `httpx.AsyncClient` for SSE).

## Coverage / Quality

- `ruff check` clean.
- `pytest` 296 passed, 1 skipped.
- Coverage: 98.6% overall, 97% on `orchestrator/api/tasks.py` (>= 95% gate).

## Scope

Only `orchestrator/api/tasks.py` (new), `orchestrator/api/app.py` (router mount only - kept minimal & idempotent for #11 union-merge), `tests/api/test_tasks.py`, and `pyproject.toml` (FastAPI/Starlette deps).
