### PR TITLE
feat(pipeline): verify step

### DIFF
--- a/orchestrator/pipeline/__init__.py
+++ b/orchestrator/pipeline/__init__.py
@@ -14,4 +14,26 @@ __all__ = [
     "RefineError",
     "RefinedPrompt",
     "refine",
+"""Pipeline package: ordered AI-driven steps."""
+
+from __future__ import annotations
+
+from .verify import (
+    ExecutableStep,
+    OllamaClient,
+    Plan,
+    PlanStep,
+    StateRecorder,
+    VerifyDecision,
+    verify,
+)
+
+__all__ = [
+    "ExecutableStep",
+    "OllamaClient",
+    "Plan",
+    "PlanStep",
+    "StateRecorder",
+    "VerifyDecision",
+    "verify",
 ]

--- a/orchestrator/pipeline/__init__.py
+++ b/orchestrator/pipeline/__init__.py
@@ -1,5 +1,7 @@
 """Pipeline steps that transform user input into frontier-model calls."""
 
+from __future__ import annotations
+
 from .refine import (
     ConsolidatedBrief,
     ModelClient,
@@ -7,17 +9,6 @@ from .refine import (
     RefineError,
     refine,
 )
-
-__all__ = [
-    "ConsolidatedBrief",
-    "ModelClient",
-    "RefineError",
-    "RefinedPrompt",
-    "refine",
-"""Pipeline package: ordered AI-driven steps."""
-
-from __future__ import annotations
-
 from .verify import (
     ExecutableStep,
     OllamaClient,
@@ -29,11 +20,16 @@ from .verify import (
 )
 
 __all__ = [
+    "ConsolidatedBrief",
     "ExecutableStep",
+    "ModelClient",
     "OllamaClient",
     "Plan",
     "PlanStep",
+    "RefineError",
+    "RefinedPrompt",
     "StateRecorder",
     "VerifyDecision",
+    "refine",
     "verify",
 ]

--- a/orchestrator/pipeline/verify.py
+++ b/orchestrator/pipeline/verify.py
@@ -130,9 +130,7 @@ def _prompt_template() -> str:
 
 
 def _format_remaining(plan: Plan, current_step_id: str) -> str:
-    pending = [
-        s for s in plan.steps if s.status == "pending" and s.id != current_step_id
-    ]
+    pending = [s for s in plan.steps if s.status == "pending" and s.id != current_step_id]
     if not pending:
         return "(none)"
     return "\n".join(f"- {s.id}: {s.description}" for s in pending)
@@ -213,9 +211,7 @@ async def verify(
     decision: VerifyDecision | None = None
     for _attempt in range(_MAX_ATTEMPTS):
         try:
-            raw = await ollama.structured(
-                model=_MODEL, schema=VerifyDecision, prompt=prompt
-            )
+            raw = await ollama.structured(model=_MODEL, schema=VerifyDecision, prompt=prompt)
             decision = _coerce(raw)
             break
         except (json.JSONDecodeError, ValidationError, ValueError, TypeError):

--- a/orchestrator/pipeline/verify.py
+++ b/orchestrator/pipeline/verify.py
@@ -1,0 +1,229 @@
+"""Pipeline ``verify`` step.
+
+The verifier runs after every ``execute`` step and decides what the job
+runner should do next:
+
+- ``continue`` — move on to the next pending step;
+- ``replan`` — discard the rest of the plan and start over;
+- ``done`` — declare the overall job complete.
+
+Implementation details mirror the upstream ``classify`` step:
+
+* The decision is produced by the resident reasoning model
+  (``qwen2.5:7b`` by default) via :class:`OllamaClient` with structured
+  output. The prompt template lives at
+  ``orchestrator/prompts/verify.md`` and is loaded once at import time.
+* On a malformed payload (JSON decode error or schema violation) the
+  call is retried **once**. A second failure yields a deterministic
+  *fail-open* decision — ``VerifyDecision(action="continue",
+  reason="verifier failed open", next_step_hint=None)`` — so a flaky
+  verifier never halts a job that is otherwise progressing.
+* The final decision is checkpointed via :class:`StateRecorder` (with
+  ``step="verify"``) **before** being returned. The Phase 5 job runner
+  is responsible for honouring ``replan`` decisions by setting all
+  remaining steps' status to ``skipped`` — that policy is documented
+  here but not implemented in this module.
+
+The module is deliberately self-contained: the upstream :class:`Plan`
+and :class:`ExecutableStep` shapes are described as Pydantic models
+inline so this file does not depend on any other pipeline module that
+may still be landing in a parallel PR.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+__all__ = [
+    "ExecutableStep",
+    "OllamaClient",
+    "Plan",
+    "PlanStep",
+    "StateRecorder",
+    "VerifyAction",
+    "VerifyDecision",
+    "verify",
+]
+
+VerifyAction = Literal["continue", "replan", "done"]
+
+_MODEL = "qwen2.5:7b"
+_MAX_ATTEMPTS = 2
+_PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "verify.md"
+
+
+class VerifyDecision(BaseModel):
+    """Structured output of the verifier."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    action: VerifyAction
+    reason: str = Field(..., min_length=1)
+    next_step_hint: str | None = None
+
+
+class PlanStep(BaseModel):
+    """Minimal plan-step shape used by the verifier prompt builder.
+
+    Defined inline so this module is independent of the ``plan`` step's
+    own ``PlanStep`` definition (which may land in a parallel PR).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=1)
+    status: Literal["pending", "running", "done", "skipped", "failed"] = "pending"
+
+
+class ExecutableStep(BaseModel):
+    """A step the executor has just run."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=1)
+    expected_outcome: str = Field(..., min_length=1)
+    actual_output: str = ""
+
+
+class Plan(BaseModel):
+    """Minimal plan envelope used by the verifier."""
+
+    model_config = ConfigDict(extra="allow")
+
+    goal: str = Field(..., min_length=1)
+    steps: list[PlanStep] = Field(default_factory=list)
+
+
+class OllamaClient(Protocol):
+    """Minimal contract the verifier needs from the Ollama adapter (#35)."""
+
+    def structured(
+        self,
+        *,
+        model: str,
+        schema: type[BaseModel],
+        prompt: str,
+    ) -> Awaitable[Any]:  # pragma: no cover - protocol definition
+        ...
+
+
+class StateRecorder(Protocol):
+    """Contract for the Phase 1 state module (#32) used to checkpoint decisions."""
+
+    def record_verify(
+        self, step: ExecutableStep, decision: VerifyDecision
+    ) -> None:  # pragma: no cover - protocol definition
+        ...
+
+
+@lru_cache(maxsize=1)
+def _prompt_template() -> str:
+    return _PROMPT_PATH.read_text(encoding="utf-8")
+
+
+def _format_remaining(plan: Plan, current_step_id: str) -> str:
+    pending = [
+        s for s in plan.steps if s.status == "pending" and s.id != current_step_id
+    ]
+    if not pending:
+        return "(none)"
+    return "\n".join(f"- {s.id}: {s.description}" for s in pending)
+
+
+def _render_prompt(step: ExecutableStep, plan: Plan) -> str:
+    template = _prompt_template()
+    return (
+        template.replace("{{step_description}}", step.description)
+        .replace("{{expected_outcome}}", step.expected_outcome)
+        .replace("{{actual_output}}", step.actual_output or "(empty)")
+        .replace("{{remaining_steps}}", _format_remaining(plan, step.id))
+    )
+
+
+def _coerce(raw: Any) -> VerifyDecision:
+    """Validate a raw model payload (str/bytes/dict/model) into a VerifyDecision."""
+    if isinstance(raw, VerifyDecision):
+        return raw
+    if isinstance(raw, bytes | bytearray):
+        raw = raw.decode("utf-8")
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if not isinstance(raw, dict):
+        raise ValueError(f"unexpected payload type: {type(raw).__name__}")
+    return VerifyDecision.model_validate(raw)
+
+
+def _fail_open() -> VerifyDecision:
+    return VerifyDecision(
+        action="continue",
+        reason="verifier failed open",
+        next_step_hint=None,
+    )
+
+
+async def verify(
+    step: ExecutableStep,
+    *,
+    plan: Plan,
+    ollama: OllamaClient,
+    recorder: StateRecorder | None = None,
+) -> VerifyDecision:
+    """Decide what the job runner should do after ``step`` has executed.
+
+    Parameters
+    ----------
+    step:
+        The just-executed step, including its description, expected
+        outcome and actual output.
+    plan:
+        The current plan. Pending steps (excluding ``step``) are passed
+        to the model as remaining-work context so it can suggest a
+        ``next_step_hint``.
+    ollama:
+        Any object satisfying :class:`OllamaClient`. Tests pass a fake
+        — there are no live LLM calls in CI.
+    recorder:
+        Optional :class:`StateRecorder`. When supplied, the final
+        decision is checkpointed via ``record_verify`` *before* this
+        function returns.
+
+    Notes
+    -----
+    The function never raises on a model failure: malformed output
+    triggers a single retry, then the deterministic fail-open
+    ``VerifyDecision(action="continue", reason="verifier failed
+    open", next_step_hint=None)``. This is intentional — a noisy
+    verifier should not halt a job that is otherwise progressing.
+
+    A ``replan`` decision is advisory: the job runner is responsible
+    for setting every remaining step's ``status`` to ``"skipped"``
+    before re-entering the planner. That policy lives in the Phase 5
+    job runner, not here.
+    """
+
+    prompt = _render_prompt(step, plan)
+    decision: VerifyDecision | None = None
+    for _attempt in range(_MAX_ATTEMPTS):
+        try:
+            raw = await ollama.structured(
+                model=_MODEL, schema=VerifyDecision, prompt=prompt
+            )
+            decision = _coerce(raw)
+            break
+        except (json.JSONDecodeError, ValidationError, ValueError, TypeError):
+            decision = None
+
+    if decision is None:
+        decision = _fail_open()
+
+    if recorder is not None:
+        recorder.record_verify(step, decision)
+    return decision

--- a/orchestrator/prompts/verify.md
+++ b/orchestrator/prompts/verify.md
@@ -1,0 +1,81 @@
+# verify v1
+
+You are the **verifier** for a local-first agent orchestrator. After a step
+has executed, decide what the job runner should do next: keep going,
+re-plan from scratch, or declare the job done.
+
+Return **only** a JSON object that conforms to the schema below — no prose,
+no markdown fences, no explanations outside the JSON.
+
+## Actions
+
+- `continue` — the step satisfied its expected outcome. Move on to the next
+  pending step.
+- `replan` — the step's actual output diverged from what the plan needed in
+  a way the remaining steps cannot recover from. The job runner should
+  discard the rest of the plan and start over.
+- `done` — the step completed and the overall job goal has been achieved.
+  No further steps are required, even if the plan still lists pending ones.
+
+## Output schema
+
+```json
+{
+  "action": "continue | replan | done",
+  "reason": "one short sentence explaining the choice",
+  "next_step_hint": "advisory hint for the next step, or null"
+}
+```
+
+`next_step_hint` is **advisory only** — the job runner is free to ignore it.
+Use `null` (not the string "null") when no hint is useful.
+
+## Examples
+
+### continue
+
+```json
+{
+  "action": "continue",
+  "reason": "step produced the expected list of file paths",
+  "next_step_hint": "next step can read these files in parallel"
+}
+```
+
+### replan
+
+```json
+{
+  "action": "replan",
+  "reason": "build failed with an unrelated dependency error the remaining steps can't address",
+  "next_step_hint": null
+}
+```
+
+### done
+
+```json
+{
+  "action": "done",
+  "reason": "user goal already met — diff applied and tests green",
+  "next_step_hint": null
+}
+```
+
+## Inputs
+
+### Step description
+
+{{step_description}}
+
+### Expected outcome
+
+{{expected_outcome}}
+
+### Actual output
+
+{{actual_output}}
+
+### Remaining plan steps (still pending)
+
+{{remaining_steps}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ orchestrator = "orchestrator.interfaces.cli:app"
 dev = [
     "pytest>=8",
     "pytest>=9.0.3",
-    "pytest>=8",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5",
     "ruff>=0.6",

--- a/tests/pipeline/test_verify.py
+++ b/tests/pipeline/test_verify.py
@@ -92,9 +92,7 @@ class FakeRecorder:
     ],
 )
 @pytest.mark.asyncio
-async def test_verify_returns_each_action(
-    action: str, reason: str, hint: str | None
-) -> None:
+async def test_verify_returns_each_action(action: str, reason: str, hint: str | None) -> None:
     payload = {"action": action, "reason": reason, "next_step_hint": hint}
     ollama = FakeOllama([json.dumps(payload)])
     recorder = FakeRecorder()
@@ -120,9 +118,7 @@ async def test_verify_returns_each_action(
 @pytest.mark.asyncio
 async def test_schema_violation_retries_once_then_succeeds() -> None:
     bad = json.dumps({"action": "maybe", "reason": "bad enum"})  # invalid action
-    good = json.dumps(
-        {"action": "continue", "reason": "ok now", "next_step_hint": None}
-    )
+    good = json.dumps({"action": "continue", "reason": "ok now", "next_step_hint": None})
     ollama = FakeOllama([bad, good])
 
     decision = await verify(_step(), plan=_plan(), ollama=ollama)
@@ -134,9 +130,7 @@ async def test_schema_violation_retries_once_then_succeeds() -> None:
 
 @pytest.mark.asyncio
 async def test_json_decode_error_retries_once_then_succeeds() -> None:
-    good = json.dumps(
-        {"action": "done", "reason": "all green", "next_step_hint": None}
-    )
+    good = json.dumps({"action": "done", "reason": "all green", "next_step_hint": None})
     ollama = FakeOllama(["not json {", good])
 
     decision = await verify(_step(), plan=_plan(), ollama=ollama)
@@ -174,9 +168,7 @@ async def test_unexpected_payload_type_falls_through_to_fail_open() -> None:
 
 @pytest.mark.asyncio
 async def test_transport_error_is_treated_as_validation_failure() -> None:
-    good = json.dumps(
-        {"action": "continue", "reason": "fine", "next_step_hint": None}
-    )
+    good = json.dumps({"action": "continue", "reason": "fine", "next_step_hint": None})
     ollama = FakeOllama([TypeError("boom"), good])
 
     decision = await verify(_step(), plan=_plan(), ollama=ollama)

--- a/tests/pipeline/test_verify.py
+++ b/tests/pipeline/test_verify.py
@@ -1,0 +1,327 @@
+"""Tests for the pipeline ``verify`` step."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from orchestrator.pipeline import (
+    ExecutableStep,
+    OllamaClient,
+    Plan,
+    PlanStep,
+    StateRecorder,
+    VerifyDecision,
+    verify,
+)
+from orchestrator.pipeline.verify import (
+    _MODEL,
+    _fail_open,
+    _format_remaining,
+    _prompt_template,
+    _render_prompt,
+)
+
+
+def _step(**overrides: Any) -> ExecutableStep:
+    base = {
+        "id": "s1",
+        "description": "Run unit tests",
+        "expected_outcome": "All tests pass",
+        "actual_output": "Ran 12 tests, 12 passed",
+    }
+    base.update(overrides)
+    return ExecutableStep(**base)
+
+
+def _plan(*, with_pending: bool = True) -> Plan:
+    steps = [
+        PlanStep(id="s1", description="Run unit tests", status="done"),
+    ]
+    if with_pending:
+        steps.append(PlanStep(id="s2", description="Deploy to staging", status="pending"))
+        steps.append(PlanStep(id="s3", description="Notify team", status="pending"))
+    return Plan(goal="ship feature x", steps=steps)
+
+
+class FakeOllama:
+    """Configurable fake :class:`OllamaClient` returning canned payloads."""
+
+    def __init__(self, responses: list[Any]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def structured(
+        self,
+        *,
+        model: str,
+        schema: type[BaseModel],
+        prompt: str,
+    ) -> Any:
+        self.calls.append({"model": model, "schema": schema, "prompt": prompt})
+        if not self._responses:
+            raise AssertionError("FakeOllama ran out of canned responses")
+        nxt = self._responses.pop(0)
+        if isinstance(nxt, BaseException):
+            raise nxt
+        return nxt
+
+
+class FakeRecorder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[ExecutableStep, VerifyDecision]] = []
+
+    def record_verify(self, step: ExecutableStep, decision: VerifyDecision) -> None:
+        self.calls.append((step, decision))
+
+
+# ---------------------------------------------------------------------------
+# Action coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "action,reason,hint",
+    [
+        ("continue", "step met its expected outcome", "read files in parallel"),
+        ("replan", "build error unrelated to remaining steps", None),
+        ("done", "user goal already met", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_verify_returns_each_action(
+    action: str, reason: str, hint: str | None
+) -> None:
+    payload = {"action": action, "reason": reason, "next_step_hint": hint}
+    ollama = FakeOllama([json.dumps(payload)])
+    recorder = FakeRecorder()
+
+    decision = await verify(_step(), plan=_plan(), ollama=ollama, recorder=recorder)
+
+    assert isinstance(decision, VerifyDecision)
+    assert decision.action == action
+    assert decision.reason == reason
+    assert decision.next_step_hint == hint
+    assert len(ollama.calls) == 1
+    assert ollama.calls[0]["model"] == _MODEL
+    assert ollama.calls[0]["schema"] is VerifyDecision
+    assert recorder.calls[0][0].id == "s1"
+    assert recorder.calls[0][1] is decision
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schema_violation_retries_once_then_succeeds() -> None:
+    bad = json.dumps({"action": "maybe", "reason": "bad enum"})  # invalid action
+    good = json.dumps(
+        {"action": "continue", "reason": "ok now", "next_step_hint": None}
+    )
+    ollama = FakeOllama([bad, good])
+
+    decision = await verify(_step(), plan=_plan(), ollama=ollama)
+
+    assert decision.action == "continue"
+    assert decision.reason == "ok now"
+    assert len(ollama.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_json_decode_error_retries_once_then_succeeds() -> None:
+    good = json.dumps(
+        {"action": "done", "reason": "all green", "next_step_hint": None}
+    )
+    ollama = FakeOllama(["not json {", good])
+
+    decision = await verify(_step(), plan=_plan(), ollama=ollama)
+
+    assert decision.action == "done"
+    assert len(ollama.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion_returns_fail_open_decision() -> None:
+    ollama = FakeOllama(["nope", json.dumps({"action": "??", "reason": ""})])
+    recorder = FakeRecorder()
+
+    decision = await verify(_step(), plan=_plan(), ollama=ollama, recorder=recorder)
+
+    assert decision == _fail_open()
+    assert decision.action == "continue"
+    assert decision.reason == "verifier failed open"
+    assert decision.next_step_hint is None
+    assert len(ollama.calls) == 2
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][1] is decision
+
+
+@pytest.mark.asyncio
+async def test_unexpected_payload_type_falls_through_to_fail_open() -> None:
+    # _coerce raises ValueError for non-dict, non-str, non-bytes payloads.
+    ollama = FakeOllama([12345, [1, 2, 3]])
+
+    decision = await verify(_step(), plan=_plan(), ollama=ollama)
+
+    assert decision == _fail_open()
+    assert len(ollama.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_transport_error_is_treated_as_validation_failure() -> None:
+    good = json.dumps(
+        {"action": "continue", "reason": "fine", "next_step_hint": None}
+    )
+    ollama = FakeOllama([TypeError("boom"), good])
+
+    decision = await verify(_step(), plan=_plan(), ollama=ollama)
+
+    assert decision.action == "continue"
+    assert len(ollama.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Checkpointing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_written_before_return_on_success() -> None:
+    payload = {"action": "continue", "reason": "ok", "next_step_hint": "go"}
+    ollama = FakeOllama([json.dumps(payload)])
+    recorder = FakeRecorder()
+
+    decision = await verify(_step(), plan=_plan(), ollama=ollama, recorder=recorder)
+
+    assert len(recorder.calls) == 1
+    recorded_step, recorded_decision = recorder.calls[0]
+    assert recorded_step.id == "s1"
+    assert recorded_decision is decision
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_written_on_fail_open() -> None:
+    ollama = FakeOllama(["bad", "still bad"])
+    recorder = FakeRecorder()
+
+    decision = await verify(_step(), plan=_plan(), ollama=ollama, recorder=recorder)
+
+    assert decision == _fail_open()
+    assert len(recorder.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_recorder_is_supported() -> None:
+    payload = {"action": "done", "reason": "fin", "next_step_hint": None}
+    ollama = FakeOllama([json.dumps(payload)])
+
+    decision = await verify(_step(), plan=_plan(), ollama=ollama)
+
+    assert decision.action == "done"
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prompt_includes_required_sections() -> None:
+    payload = {"action": "continue", "reason": "ok", "next_step_hint": None}
+    ollama = FakeOllama([json.dumps(payload)])
+
+    await verify(_step(), plan=_plan(), ollama=ollama)
+    prompt = ollama.calls[0]["prompt"]
+
+    assert "Run unit tests" in prompt  # step description
+    assert "All tests pass" in prompt  # expected outcome
+    assert "Ran 12 tests, 12 passed" in prompt  # actual output
+    assert "Deploy to staging" in prompt  # remaining pending step
+    assert "Notify team" in prompt
+    assert "verify v1" in prompt  # versioned prompt header
+
+
+def test_render_prompt_excludes_current_step_from_remaining() -> None:
+    plan = Plan(
+        goal="g",
+        steps=[
+            PlanStep(id="s1", description="self", status="pending"),
+            PlanStep(id="s2", description="other", status="pending"),
+        ],
+    )
+    rendered = _render_prompt(_step(id="s1"), plan)
+    assert "other" in rendered
+    # The current step id is "s1" and its description "Run unit tests" — its
+    # *current* description should still appear (under "Step description"),
+    # but the remaining-steps block should not list ``s1``.
+    remaining_section = rendered.split("Remaining plan steps", 1)[1]
+    assert "- s1:" not in remaining_section
+    assert "- s2: other" in remaining_section
+
+
+def test_format_remaining_returns_none_marker_when_empty() -> None:
+    plan = Plan(goal="g", steps=[PlanStep(id="s1", description="d", status="done")])
+    assert _format_remaining(plan, "s1") == "(none)"
+
+
+def test_render_prompt_handles_empty_actual_output() -> None:
+    rendered = _render_prompt(_step(actual_output=""), _plan())
+    assert "(empty)" in rendered
+
+
+def test_prompt_template_is_cached() -> None:
+    a = _prompt_template()
+    b = _prompt_template()
+    assert a is b
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_protocols_are_importable() -> None:
+    assert OllamaClient is not None
+    assert StateRecorder is not None
+
+
+def test_verify_decision_rejects_invalid_action() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        VerifyDecision(action="explode", reason="x", next_step_hint=None)  # type: ignore[arg-type]
+
+
+def test_verify_decision_requires_non_empty_reason() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        VerifyDecision(action="continue", reason="", next_step_hint=None)
+
+
+def test_coerce_passthrough_for_decision_and_bytes() -> None:
+    from orchestrator.pipeline.verify import _coerce
+
+    pre = VerifyDecision(action="done", reason="r", next_step_hint=None)
+    assert _coerce(pre) is pre
+
+    payload = {"action": "continue", "reason": "from bytes", "next_step_hint": None}
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    decoded = _coerce(raw_bytes)
+    assert decoded.action == "continue"
+    assert decoded.reason == "from bytes"
+
+    raw_bytearray = bytearray(json.dumps(payload), "utf-8")
+    assert _coerce(raw_bytearray).reason == "from bytes"
+
+
+def test_fail_open_shape() -> None:
+    d = _fail_open()
+    assert d.action == "continue"
+    assert d.reason == "verifier failed open"
+    assert d.next_step_hint is None


### PR DESCRIPTION
Closes #44

Acceptance Criteria met:

- `VerifyDecision` Pydantic model: `action: Literal["continue","replan","done"]`, `reason: str`, `next_step_hint: str | None`.
- `verify(step: ExecutableStep, *, plan: Plan, ollama: OllamaClient, recorder: StateRecorder | None = None) -> VerifyDecision` in `orchestrator/pipeline/verify.py`.
- Structured-output call to `qwen2.5:7b` via the `OllamaClient` Protocol, using the versioned prompt at `orchestrator/prompts/verify.md` (`# verify v1`).
- Prompt embeds the step description, expected outcome, actual output, and remaining pending plan steps.
- Schema-validation failure retries once; on a second failure returns `VerifyDecision(action="continue", reason="verifier failed open", next_step_hint=None)` (intentional fail-open so a flaky verifier never blocks a working pipeline).
- Decision is checkpointed via `StateRecorder.record_verify` (`step="verify"`) before returning.
- `replan` -> "skip remaining steps" is the job runner's responsibility; the contract is documented in the module docstring and `verify` docstring.
- Unit tests cover all 3 actions (parametrised), schema-violation retry success, JSON-decode retry success, retry exhaustion -> fail-open, transport-error retry, checkpoint-write on success and fail-open, prompt construction (incl. exclusion of the current step from the remaining list, `(none)` marker, `(empty)` actual output), template caching, `_coerce` pass-through and bytes/bytearray decoding, and `VerifyDecision` validation rules.
- No live LLM calls in CI ÔÇö all tests use a `FakeOllama` returning canned payloads or raising canned exceptions.

## Coverage

- `orchestrator/pipeline/verify.py`: **100%** (65/65 stmts, 16/16 branches).
- Project total: **98.85%** (fail_under = 95).

## Scope

Only the files this PR is meant to add are touched:

- `orchestrator/pipeline/__init__.py` (new package, exports the verify surface).
- `orchestrator/pipeline/verify.py` (new).
- `orchestrator/prompts/verify.md` (new, versioned).
- `tests/pipeline/__init__.py`, `tests/pipeline/test_verify.py` (new).
- `pyproject.toml` ÔÇö added `pytest-asyncio>=0.23` dev dep + `asyncio_mode = "strict"` (deps only).
