### PR TITLE
ci(release): GHCR multi-arch image publish

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,132 @@
+name: release-image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
+jobs:
+  build:
+    name: build (${{ matrix.variant }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: slim
+            image: orchestrator
+            dockerfile: Dockerfile
+          - variant: browser
+            image: orchestrator-browser
+            dockerfile: Dockerfile.browser
+    outputs:
+      slim-digest: ${{ steps.export.outputs.slim-digest }}
+      browser-digest: ${{ steps.export.outputs.browser-digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=ref,event=branch,enable=${{ github.ref == format('refs/heads/{0}', 'main') }},value=edge
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
+          provenance: true
+          sbom: true
+
+      - name: Export digest
+        id: export
+        run: echo "${{ matrix.variant }}-digest=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: verify multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=edge" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Inspect slim manifest (amd64 + arm64 present)
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${OWNER}/orchestrator:${{ steps.tag.outputs.tag }}"
+          echo "Inspecting ${IMAGE}"
+          docker buildx imagetools inspect "${IMAGE}" | tee inspect.txt
+          grep -q "linux/amd64" inspect.txt
+          grep -q "linux/arm64" inspect.txt
+
+      - name: Inspect browser manifest (amd64 + arm64 present)
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${OWNER}/orchestrator-browser:${{ steps.tag.outputs.tag }}"
+          echo "Inspecting ${IMAGE}"
+          docker buildx imagetools inspect "${IMAGE}" | tee inspect-browser.txt
+          grep -q "linux/amd64" inspect-browser.txt
+          grep -q "linux/arm64" inspect-browser.txt
+
+      - name: Smoke-test slim image (native arch)
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${OWNER}/orchestrator:${{ steps.tag.outputs.tag }}"
+          docker pull "${IMAGE}"
+          docker run --rm --entrypoint python "${IMAGE}" -c "import orchestrator; print('orchestrator import OK')"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ opencode / Claude Code / codex
 
 Full design details: [`docs/PLAN.md`](docs/PLAN.md).
 
+## Run with Docker
+
+Multi-arch (`linux/amd64` + `linux/arm64`) images are published to GHCR by the
+[`release-image`](.github/workflows/release-image.yml) workflow. Two variants:
+
+- `ghcr.io/skgandikota/orchestrator` — slim runtime, no browser deps.
+- `ghcr.io/skgandikota/orchestrator-browser` — slim + Playwright/Chromium.
+
+```bash
+docker run --rm -p 8000:8000 \
+  -v "$HOME/.config/orchestrator:/etc/orchestrator" \
+  -v "$HOME/.local/share/orchestrator:/var/lib/orchestrator" \
+  ghcr.io/skgandikota/orchestrator:latest
+```
+
+Tags: `:latest` (newest semver), `:vX.Y.Z` / `:vX.Y` / `:vX` (per release),
+`:edge` (head of `main`). See [`docs/RELEASES.md`](docs/RELEASES.md) for the
+release process and verification steps.
+
 ## Integrations
 
 Per-tool how-to guides for plugging orchestrator into the coding agents

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,108 @@
+# Releases
+
+This document describes how to cut a release and verify the published container
+images for `orchestrator`.
+
+## Container images
+
+Two multi-arch images (`linux/amd64` + `linux/arm64`) are published to GHCR by
+the [`release-image`](../.github/workflows/release-image.yml) workflow:
+
+| Image | Contents |
+|-------|----------|
+| `ghcr.io/skgandikota/orchestrator` | Slim runtime (no browser deps) — built from `Dockerfile`. |
+| `ghcr.io/skgandikota/orchestrator-browser` | Slim runtime + Playwright/Chromium — built from `Dockerfile.browser`. |
+
+### Tag scheme
+
+| Trigger | Tags applied |
+|---------|--------------|
+| Push to `main` | `:edge` |
+| Push of tag `vX.Y.Z` | `:vX.Y.Z`, `:vX.Y`, `:vX`, `:latest` |
+| `workflow_dispatch` | (no tag — manual run, useful for cache warming) |
+
+The workflow uses `docker/metadata-action@v5`, `docker/setup-buildx-action@v3`,
+`docker/setup-qemu-action@v3`, `docker/login-action@v3`, and
+`docker/build-push-action@v6`. Build cache is GitHub Actions cache
+(`type=gha`) scoped per variant. Provenance and SBOM attestations are enabled.
+
+## Cutting a release
+
+1. **Confirm `main` is green** — CI, CodeQL, and the most recent
+   `release-image` run on `main` (which produces `:edge`) must all be green.
+2. **Update the changelog** if applicable (or rely on GitHub-generated notes).
+3. **Tag the release** from `main`:
+
+   ```bash
+   git checkout main
+   git pull --ff-only
+   git tag -s v0.1.0 -m "v0.1.0"
+   git push origin v0.1.0
+   ```
+
+   Signed tags (`-s`) are preferred so the release artefact can be verified.
+
+4. **Watch the workflow** — pushing the tag triggers `release-image`. The
+   `build (slim)` and `build (browser)` jobs run in parallel; `verify` runs
+   after both succeed and inspects each manifest list to confirm both
+   architectures are present.
+
+5. **Flip package visibility to public (one-time, per image)** — after the
+   first successful publish, on github.com:
+   `Your profile → Packages → orchestrator → Package settings → Change
+   visibility → Public`. Repeat for `orchestrator-browser`. Documented in
+   [`docs/DEPLOY.md`](DEPLOY.md).
+
+6. **Publish a GitHub Release** referencing the tag. Auto-generated release
+   notes are usually sufficient.
+
+## Verifying a published image
+
+After the workflow finishes, anyone can pull the image without authenticating
+(once the package is public):
+
+```bash
+# Edge — built on every push to main
+docker pull ghcr.io/skgandikota/orchestrator:edge
+
+# Latest tagged release
+docker pull ghcr.io/skgandikota/orchestrator:latest
+
+# Specific version
+docker pull ghcr.io/skgandikota/orchestrator:v0.1.0
+```
+
+Confirm the manifest is multi-arch:
+
+```bash
+docker buildx imagetools inspect ghcr.io/skgandikota/orchestrator:edge
+# Expect to see entries for both linux/amd64 and linux/arm64.
+```
+
+Smoke-test the container:
+
+```bash
+docker run --rm --entrypoint python \
+  ghcr.io/skgandikota/orchestrator:edge \
+  -c "import orchestrator; print('ok')"
+```
+
+Run the HTTP API locally (the image's default `CMD`):
+
+```bash
+docker run --rm -p 8000:8000 \
+  -v "$HOME/.config/orchestrator:/etc/orchestrator" \
+  -v "$HOME/.local/share/orchestrator:/var/lib/orchestrator" \
+  ghcr.io/skgandikota/orchestrator:edge
+# Then:
+curl http://localhost:8000/v1/models
+```
+
+## Re-running a release
+
+If a release run fails part-way, re-run failed jobs from the Actions UI. The
+workflow is idempotent — `docker/build-push-action` will reuse the GHA cache
+and `metadata-action` will compute identical tags.
+
+To force a fresh build without bumping the tag, use **Run workflow** from the
+Actions tab (`workflow_dispatch`).


### PR DESCRIPTION
Closes #48

## Summary

Adds `.github/workflows/release-image.yml` to publish multi-arch
(`linux/amd64` + `linux/arm64`) Docker images to GHCR for both
the slim runtime and the browser variant.

| Trigger | Tags |
|---|---|
| push to `main` | `:edge` |
| push of tag `v*` | `:vX.Y.Z`, `:vX.Y`, `:vX`, `:latest` |
| `workflow_dispatch` | manual |

## Acceptance Criteria met

- [x] Workflow triggers: push to main, push of `v*` tag, `workflow_dispatch`.
- [x] Uses `docker/setup-qemu-action@v3`, `docker/setup-buildx-action@v3`, `docker/login-action@v3` (GHCR via `GITHUB_TOKEN`), `docker/metadata-action@v5`, `docker/build-push-action@v6`.
- [x] Single buildx invocation produces a multi-arch manifest list per image (not a job matrix of separate images).
- [x] Two images per run: `ghcr.io/skgandikota/orchestrator` (slim) and `ghcr.io/skgandikota/orchestrator-browser` (from `Dockerfile.browser`).
- [x] Tags applied via `metadata-action`: `edge` on main, `latest` + `vX.Y.Z` / `vX.Y` / `vX` on semver.
- [x] Build cache: `type=gha`, scoped per variant.
- [x] `provenance: true`, `sbom: true`.
- [x] `permissions`: `contents: read`, `packages: write`, `id-token: write`.
- [x] `verify` job inspects each multi-arch manifest (asserts both arches present) and smoke-tests the slim image.
- [x] `docs/RELEASES.md` documents cutting a `v0.1.0` tag and verifying the published image (`docker pull ghcr.io/skgandikota/orchestrator:edge`).
- [x] README has a *Run with Docker* section pointing at `ghcr.io/skgandikota/orchestrator:latest`.
- [x] Public-visibility flip remains a one-time manual step (already documented in `docs/DEPLOY.md` and re-pointed from `RELEASES.md`).

## Validation

- `python -m ruff check .` clean.
- `pytest` 275 passed, 1 skipped (env-dependent symlink test, pre-existing).
- Config-only PR; no Python source changed, so coverage delta is zero.
