### PR TITLE
fix(ci): break PR reviewer bot death loop

### DIFF
--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -19,8 +19,6 @@ name: PR Reviewer Bot
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
   issue_comment:
     types: [created]
   check_run:
@@ -38,16 +36,15 @@ permissions:
 
 concurrency:
   group: pr-review-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.issue.number || inputs.pr_number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   review:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.draft != true && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_review' && github.event.pull_request.draft != true && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
-      (github.event_name == 'check_run' && github.event.check_run.pull_requests[0] != null)
+      (github.event_name == 'pull_request_target' && github.event.pull_request.draft != true && github.event.pull_request.head.repo.full_name == github.repository && github.event.sender.type != 'Bot') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.sender.type != 'Bot') ||
+      (github.event_name == 'check_run' && github.event.check_run.pull_requests[0] != null && github.event.check_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR number


### PR DESCRIPTION
Closes #107

## Problem
Reviewer-bot was hitting GitHub API rate limit (HTTP 403) due to a tight cancel/restart loop:
1. Bot submits approval
2. `pull_request_review.submitted` fires
3. `concurrency.cancel-in-progress: true` cancels the in-flight merge step
4. New run starts, finds PR not yet merged, approves again → goto 1

Result: 9 PRs (#108, #109, #111-#113, #115-#118) stuck BLOCKED awaiting bot approval.

## Fix
- Drop `pull_request_review` trigger (redundant; `check_run` + `pull_request_target` cover all needed state changes)
- Flip `cancel-in-progress: false` so concurrent invocations queue safely
- Add `sender.type != 'Bot'` guard on `pull_request_target` and `issue_comment` to ignore bot self-events
- Only run on `check_run.conclusion == 'success'` (skip in_progress / cancelled / queued runs)

## Acceptance Criteria met
- [x] No more bot-triggered self-runs
- [x] No more mid-merge cancellations
- [x] Workflow still triggers on PR open/sync/labels/CI-success/manual dispatch
- [x] Signed commit (key 9C8C0949390E528F)