### PR TITLE
feat(evals): classifier evaluation set

### DIFF
--- a/evals/classify/__init__.py
+++ b/evals/classify/__init__.py
@@ -1,0 +1,34 @@
+"""Classifier eval suite.
+
+Provides a golden dataset of intent-labeled prompts and a harness that
+scores a classifier callable against it (overall accuracy plus per-intent
+precision and recall).
+
+Run from the command line:
+
+.. code-block:: shell
+
+   python -m evals.classify --suite evals/classify/golden.jsonl
+"""
+
+from __future__ import annotations
+
+from evals.classify.runner import (
+    ClassifierFn,
+    ClassifyEvalReport,
+    ClassifyEvalRunner,
+    GoldenCase,
+    IntentMetrics,
+    load_golden,
+    run_classifier_eval,
+)
+
+__all__ = [
+    "ClassifierFn",
+    "ClassifyEvalReport",
+    "ClassifyEvalRunner",
+    "GoldenCase",
+    "IntentMetrics",
+    "load_golden",
+    "run_classifier_eval",
+]

--- a/evals/classify/__main__.py
+++ b/evals/classify/__main__.py
@@ -1,0 +1,108 @@
+"""CLI entrypoint: ``python -m evals.classify``.
+
+Loads the golden dataset, runs a classifier (a stub keyword classifier by
+default so the harness is exercisable in CI without a live model), and
+prints the aggregated report. Exits non-zero if accuracy falls below the
+configurable threshold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from evals.classify.runner import (
+    ClassifierFn,
+    ClassifyEvalReport,
+    format_report,
+    load_golden,
+    run_classifier_eval,
+)
+
+_DEFAULT_SUITE = Path(__file__).resolve().parent / "golden.jsonl"
+
+
+_STATUS_RE = re.compile(
+    r"\b(status|progress|update|where are we|what'?s? happening|how is .* going)\b",
+    re.IGNORECASE,
+)
+_RESEARCH_RE = re.compile(
+    r"\b(research|investigate|compare|survey|literature|find sources|cite)\b",
+    re.IGNORECASE,
+)
+_DEEP_RE = re.compile(
+    r"\b(refactor|design|architecture|implement|analy[sz]e|deep dive|root cause|debug)\b",
+    re.IGNORECASE,
+)
+
+
+def stub_classifier(prompt: str) -> str:
+    """Tiny keyword classifier used as the default CLI client.
+
+    Real evaluations should pass a wrapper around the production classifier.
+    """
+
+    if _STATUS_RE.search(prompt):
+        return "status"
+    if _RESEARCH_RE.search(prompt):
+        return "research"
+    if _DEEP_RE.search(prompt):
+        return "deep"
+    return "fast"
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="python -m evals.classify")
+    parser.add_argument(
+        "--suite",
+        type=Path,
+        default=_DEFAULT_SUITE,
+        help="Path to the JSONL golden dataset.",
+    )
+    parser.add_argument(
+        "--min-accuracy",
+        type=float,
+        default=0.0,
+        help="Fail the run if accuracy is below this threshold.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON report instead of plain text.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    classifier: ClassifierFn | None = None,
+) -> int:
+    args = _parse_args(argv)
+    fn = classifier or stub_classifier
+    report: ClassifyEvalReport = run_classifier_eval(fn, args.suite)
+    if args.json:
+        sys.stdout.write(report.to_json() + "\n")
+    else:
+        sys.stdout.write(format_report(report))
+    if report.accuracy < args.min_accuracy:
+        sys.stderr.write(
+            f"accuracy {report.accuracy:.3f} below threshold {args.min_accuracy:.3f}\n"
+        )
+        return 1
+    return 0
+
+
+def _entrypoint() -> None:  # pragma: no cover - thin wrapper
+    raise SystemExit(main())
+
+
+# Allow ``load_golden`` symbol re-export for ad hoc CLI scripting.
+__all__ = ["load_golden", "main", "stub_classifier"]
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry
+    _entrypoint()

--- a/evals/classify/golden.jsonl
+++ b/evals/classify/golden.jsonl
@@ -1,0 +1,36 @@
+{"prompt": "what's the status of the deploy?", "expected": "status", "notes": "direct status query"}
+{"prompt": "progress on the migration ticket?", "expected": "status", "notes": "progress keyword"}
+{"prompt": "where are we with the refactor I asked for?", "expected": "status", "notes": "where-are-we phrasing"}
+{"prompt": "give me an update on the running job", "expected": "status", "notes": "update phrasing"}
+{"prompt": "how is the research task going?", "expected": "status", "notes": "edge case: status check on a research task"}
+{"prompt": "status please", "expected": "status", "notes": "minimal status query"}
+{"prompt": "progress report on yesterday's deep refactor", "expected": "status", "notes": "tricky: mentions deep but is a status query"}
+{"prompt": "what's happening with the ingest pipeline run?", "expected": "status", "notes": "what's happening phrasing"}
+{"prompt": "what is 2 + 2?", "expected": "fast", "notes": "trivial arithmetic"}
+{"prompt": "translate 'good morning' into French", "expected": "fast", "notes": "single-shot translation"}
+{"prompt": "capital of Australia?", "expected": "fast", "notes": "single fact lookup"}
+{"prompt": "convert 100 USD to EUR", "expected": "fast", "notes": "trivial conversion"}
+{"prompt": "spell 'accommodate'", "expected": "fast", "notes": "spelling lookup"}
+{"prompt": "what does 'TTL' stand for?", "expected": "fast", "notes": "acronym expansion"}
+{"prompt": "summarize this paragraph in one sentence: ...", "expected": "fast", "notes": "short summary"}
+{"prompt": "give me a one-line definition of 'idempotent'", "expected": "fast", "notes": "definition lookup"}
+{"prompt": "refactor the auth middleware to drop the global state", "expected": "deep", "notes": "refactor keyword"}
+{"prompt": "design an event-sourced inventory module with snapshots", "expected": "deep", "notes": "design keyword"}
+{"prompt": "implement a least-recently-used cache in Python with TTL", "expected": "deep", "notes": "implement keyword"}
+{"prompt": "analyse why our P99 latency spiked last Tuesday", "expected": "deep", "notes": "analysis keyword"}
+{"prompt": "debug the flaky integration test in payments", "expected": "deep", "notes": "debug keyword"}
+{"prompt": "find the root cause of the deadlock in the scheduler", "expected": "deep", "notes": "root cause keyword"}
+{"prompt": "review architecture for the new billing service", "expected": "deep", "notes": "architecture keyword"}
+{"prompt": "deep dive on the GC tuning options for our heap", "expected": "deep", "notes": "deep dive keyword"}
+{"prompt": "research the best vector database for low-latency RAG", "expected": "research", "notes": "research keyword"}
+{"prompt": "compare Postgres logical replication vs Debezium", "expected": "research", "notes": "compare keyword"}
+{"prompt": "investigate which authentication libraries support WebAuthn", "expected": "research", "notes": "investigate keyword"}
+{"prompt": "survey current literature on differential privacy for telemetry", "expected": "research", "notes": "survey keyword"}
+{"prompt": "find sources that discuss async Python performance in 2025", "expected": "research", "notes": "find sources phrasing"}
+{"prompt": "cite peer-reviewed work on retrieval-augmented generation", "expected": "research", "notes": "cite keyword"}
+{"prompt": "research the trade-offs between gRPC and Cap'n Proto", "expected": "research", "notes": "comparative research"}
+{"prompt": "investigate vendor options for managed OpenSearch", "expected": "research", "notes": "vendor research"}
+{"prompt": "what time is it in Tokyo right now?", "expected": "fast", "notes": "edge case: trivial fact, not status"}
+{"prompt": "compare CPython and PyPy startup latency", "expected": "research", "notes": "edge case: compare without 'research'"}
+{"prompt": "implement a binary search tree with deletion", "expected": "deep", "notes": "implementation request"}
+{"prompt": "where are we on the OAuth migration?", "expected": "status", "notes": "edge case: status with project keyword"}

--- a/evals/classify/runner.py
+++ b/evals/classify/runner.py
@@ -1,0 +1,209 @@
+"""Eval harness that scores an intent classifier against a golden set.
+
+The harness is intentionally decoupled from the production classifier:
+callers pass any ``ClassifierFn`` (a sync ``str -> str`` callable) and the
+runner produces an :class:`ClassifyEvalReport` with overall accuracy and
+per-intent precision and recall. This keeps the harness CI-safe (no live
+LLM required) and makes it easy to plug in mocks in tests.
+
+Datasets are stored as JSONL where each line is a JSON object with at
+least ``prompt`` and ``expected`` keys plus optional ``notes``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+ClassifierFn = Callable[[str], str]
+"""A synchronous classifier: takes a user prompt, returns an intent label."""
+
+
+@dataclass(frozen=True)
+class GoldenCase:
+    """A single labeled prompt from the golden dataset."""
+
+    prompt: str
+    expected: str
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class IntentMetrics:
+    """Per-intent precision/recall/F1 with raw confusion counts."""
+
+    intent: str
+    support: int
+    predicted: int
+    true_positive: int
+    false_positive: int
+    false_negative: int
+    precision: float
+    recall: float
+    f1: float
+
+
+@dataclass
+class ClassifyEvalReport:
+    """Aggregate report for a classifier eval run."""
+
+    total: int
+    correct: int
+    accuracy: float
+    per_intent: dict[str, IntentMetrics]
+    confusion: dict[str, dict[str, int]]
+    misclassified: list[dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "total": self.total,
+            "correct": self.correct,
+            "accuracy": self.accuracy,
+            "per_intent": {k: asdict(v) for k, v in self.per_intent.items()},
+            "confusion": self.confusion,
+            "misclassified": self.misclassified,
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+
+def load_golden(path: str | Path) -> list[GoldenCase]:
+    """Load a JSONL golden file into :class:`GoldenCase` records."""
+
+    p = Path(path)
+    cases: list[GoldenCase] = []
+    for raw_line in p.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        record = json.loads(line)
+        if not isinstance(record, Mapping):
+            raise ValueError(f"each line must be a JSON object; got {type(record).__name__}")
+        if "prompt" not in record or "expected" not in record:
+            raise ValueError("each record requires 'prompt' and 'expected' fields")
+        cases.append(
+            GoldenCase(
+                prompt=str(record["prompt"]),
+                expected=str(record["expected"]),
+                notes=str(record.get("notes", "")),
+            )
+        )
+    if not cases:
+        raise ValueError(f"golden file {p} is empty")
+    return cases
+
+
+def _safe_div(num: float, denom: float) -> float:
+    return num / denom if denom else 0.0
+
+
+@dataclass
+class ClassifyEvalRunner:
+    """Runs a :class:`ClassifierFn` against a list of golden cases."""
+
+    classifier: ClassifierFn
+
+    def run(self, cases: Iterable[GoldenCase]) -> ClassifyEvalReport:
+        cases_list = list(cases)
+        if not cases_list:
+            raise ValueError("at least one case is required")
+
+        labels: set[str] = set()
+        confusion: dict[str, dict[str, int]] = {}
+        true_pos: Counter[str] = Counter()
+        false_pos: Counter[str] = Counter()
+        false_neg: Counter[str] = Counter()
+        support: Counter[str] = Counter()
+        predicted: Counter[str] = Counter()
+        misclassified: list[dict[str, str]] = []
+        correct = 0
+
+        for case in cases_list:
+            actual = self.classifier(case.prompt)
+            labels.add(case.expected)
+            labels.add(actual)
+            support[case.expected] += 1
+            predicted[actual] += 1
+            row = confusion.setdefault(case.expected, {})
+            row[actual] = row.get(actual, 0) + 1
+            if actual == case.expected:
+                correct += 1
+                true_pos[case.expected] += 1
+            else:
+                false_neg[case.expected] += 1
+                false_pos[actual] += 1
+                misclassified.append(
+                    {
+                        "prompt": case.prompt,
+                        "expected": case.expected,
+                        "actual": actual,
+                    }
+                )
+
+        per_intent: dict[str, IntentMetrics] = {}
+        for label in sorted(labels):
+            tp = true_pos[label]
+            fp = false_pos[label]
+            fn = false_neg[label]
+            precision = _safe_div(tp, tp + fp)
+            recall = _safe_div(tp, tp + fn)
+            f1 = _safe_div(2 * precision * recall, precision + recall)
+            per_intent[label] = IntentMetrics(
+                intent=label,
+                support=support[label],
+                predicted=predicted[label],
+                true_positive=tp,
+                false_positive=fp,
+                false_negative=fn,
+                precision=precision,
+                recall=recall,
+                f1=f1,
+            )
+
+        total = len(cases_list)
+        return ClassifyEvalReport(
+            total=total,
+            correct=correct,
+            accuracy=_safe_div(correct, total),
+            per_intent=per_intent,
+            confusion=confusion,
+            misclassified=misclassified,
+        )
+
+
+def run_classifier_eval(
+    classifier: ClassifierFn,
+    suite_path: str | Path,
+) -> ClassifyEvalReport:
+    """Convenience wrapper: load ``suite_path`` and run ``classifier``."""
+
+    return ClassifyEvalRunner(classifier=classifier).run(load_golden(suite_path))
+
+
+def format_report(report: ClassifyEvalReport) -> str:
+    """Human-readable text report (used by the CLI)."""
+
+    lines = [
+        f"accuracy: {report.accuracy:.3f}  ({report.correct}/{report.total})",
+        "",
+        f"{'intent':<12}{'support':>9}{'precision':>12}{'recall':>10}{'f1':>8}",
+        "-" * 51,
+    ]
+    for metrics in report.per_intent.values():
+        lines.append(
+            f"{metrics.intent:<12}{metrics.support:>9}"
+            f"{metrics.precision:>12.3f}{metrics.recall:>10.3f}{metrics.f1:>8.3f}"
+        )
+    if report.misclassified:
+        lines.append("")
+        lines.append("misclassified:")
+        for entry in report.misclassified:
+            lines.append(
+                f"  expected={entry['expected']:<8} actual={entry['actual']:<8} "
+                f"prompt={entry['prompt']!r}"
+            )
+    return "\n".join(lines) + "\n"

--- a/tests/evals/test_classify_runner.py
+++ b/tests/evals/test_classify_runner.py
@@ -1,0 +1,315 @@
+"""Tests for the classifier eval harness.
+
+These tests use a mocked classifier to verify the harness math: overall
+accuracy, per-intent precision/recall/F1, the confusion matrix, and the
+misclassified-row capture. The CLI entrypoint is exercised with a stub
+classifier so we never hit a live model.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from evals.classify import (
+    ClassifyEvalReport,
+    ClassifyEvalRunner,
+    GoldenCase,
+    load_golden,
+    run_classifier_eval,
+)
+from evals.classify.__main__ import main, stub_classifier
+from evals.classify.runner import format_report
+
+GOLDEN_PATH = Path(__file__).resolve().parents[2] / "evals" / "classify" / "golden.jsonl"
+
+
+def _make_cases() -> list[GoldenCase]:
+    # 6 cases, two per "expected" label: fast, deep, status
+    return [
+        GoldenCase(prompt="p-fast-1", expected="fast"),
+        GoldenCase(prompt="p-fast-2", expected="fast"),
+        GoldenCase(prompt="p-deep-1", expected="deep"),
+        GoldenCase(prompt="p-deep-2", expected="deep"),
+        GoldenCase(prompt="p-status-1", expected="status"),
+        GoldenCase(prompt="p-status-2", expected="status"),
+    ]
+
+
+def _scripted_classifier(mapping: dict[str, str]):
+    fn = MagicMock(side_effect=lambda prompt: mapping[prompt])
+    return fn
+
+
+def test_perfect_classifier_yields_full_marks() -> None:
+    cases = _make_cases()
+    fn = _scripted_classifier({c.prompt: c.expected for c in cases})
+
+    report = ClassifyEvalRunner(classifier=fn).run(cases)
+
+    assert report.total == 6
+    assert report.correct == 6
+    assert report.accuracy == 1.0
+    assert report.misclassified == []
+    for label in ("fast", "deep", "status"):
+        m = report.per_intent[label]
+        assert m.support == 2
+        assert m.predicted == 2
+        assert m.precision == 1.0
+        assert m.recall == 1.0
+        assert m.f1 == 1.0
+    assert fn.call_count == 6
+
+
+def test_metrics_with_mixed_predictions() -> None:
+    cases = _make_cases()
+    # Flip one fast -> deep (false negative for fast, false positive for deep)
+    # and one status -> fast (FN status, FP fast)
+    predictions = {
+        "p-fast-1": "fast",
+        "p-fast-2": "deep",
+        "p-deep-1": "deep",
+        "p-deep-2": "deep",
+        "p-status-1": "status",
+        "p-status-2": "fast",
+    }
+    fn = _scripted_classifier(predictions)
+
+    report = ClassifyEvalRunner(classifier=fn).run(cases)
+
+    # 4/6 correct
+    assert report.total == 6
+    assert report.correct == 4
+    assert math.isclose(report.accuracy, 4 / 6)
+
+    fast = report.per_intent["fast"]
+    assert fast.support == 2
+    assert fast.true_positive == 1
+    assert fast.false_negative == 1  # p-fast-2 -> deep
+    assert fast.false_positive == 1  # p-status-2 -> fast
+    assert math.isclose(fast.precision, 0.5)
+    assert math.isclose(fast.recall, 0.5)
+    assert math.isclose(fast.f1, 0.5)
+
+    deep = report.per_intent["deep"]
+    assert deep.true_positive == 2
+    assert deep.false_positive == 1  # p-fast-2 misrouted to deep
+    assert deep.false_negative == 0
+    assert math.isclose(deep.precision, 2 / 3)
+    assert deep.recall == 1.0
+
+    status = report.per_intent["status"]
+    assert status.true_positive == 1
+    assert status.false_negative == 1
+    assert status.false_positive == 0
+    assert status.precision == 1.0
+    assert math.isclose(status.recall, 0.5)
+
+    # Confusion matrix shape
+    assert report.confusion["fast"] == {"fast": 1, "deep": 1}
+    assert report.confusion["deep"] == {"deep": 2}
+    assert report.confusion["status"] == {"status": 1, "fast": 1}
+
+    # Misclassified rows captured with prompt+expected+actual
+    assert {(m["prompt"], m["expected"], m["actual"]) for m in report.misclassified} == {
+        ("p-fast-2", "fast", "deep"),
+        ("p-status-2", "status", "fast"),
+    }
+
+
+def test_unseen_predicted_label_gets_metrics_row() -> None:
+    cases = [GoldenCase(prompt="x", expected="fast")]
+    fn = _scripted_classifier({"x": "research"})
+
+    report = ClassifyEvalRunner(classifier=fn).run(cases)
+
+    assert report.accuracy == 0.0
+    assert "research" in report.per_intent
+    research = report.per_intent["research"]
+    assert research.support == 0
+    assert research.predicted == 1
+    assert research.precision == 0.0
+    # recall is 0 because there is no support: safe-divide returns 0
+    assert research.recall == 0.0
+    assert research.f1 == 0.0
+
+
+def test_runner_rejects_empty_iterable() -> None:
+    fn = _scripted_classifier({})
+    with pytest.raises(ValueError):
+        ClassifyEvalRunner(classifier=fn).run([])
+
+
+def test_load_golden_skips_blank_and_comment_lines(tmp_path: Path) -> None:
+    suite = tmp_path / "g.jsonl"
+    suite.write_text(
+        "\n".join(
+            [
+                "# header comment",
+                "",
+                json.dumps({"prompt": "hello", "expected": "fast"}),
+                json.dumps({"prompt": "deep dive", "expected": "deep", "notes": "n"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    cases = load_golden(suite)
+
+    assert len(cases) == 2
+    assert cases[0].prompt == "hello"
+    assert cases[1].notes == "n"
+
+
+def test_load_golden_rejects_missing_fields(tmp_path: Path) -> None:
+    suite = tmp_path / "bad.jsonl"
+    suite.write_text(json.dumps({"prompt": "x"}) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match=r"prompt.*expected"):
+        load_golden(suite)
+
+
+def test_load_golden_rejects_non_object_line(tmp_path: Path) -> None:
+    suite = tmp_path / "bad.jsonl"
+    suite.write_text(json.dumps(["nope"]) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON object"):
+        load_golden(suite)
+
+
+def test_load_golden_rejects_empty_file(tmp_path: Path) -> None:
+    suite = tmp_path / "empty.jsonl"
+    suite.write_text("# only comments\n\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="empty"):
+        load_golden(suite)
+
+
+def test_run_classifier_eval_reads_jsonl(tmp_path: Path) -> None:
+    suite = tmp_path / "g.jsonl"
+    suite.write_text(json.dumps({"prompt": "p1", "expected": "fast"}) + "\n", encoding="utf-8")
+    fn = _scripted_classifier({"p1": "fast"})
+    report = run_classifier_eval(fn, suite)
+    assert report.accuracy == 1.0
+
+
+def test_report_to_json_round_trips() -> None:
+    cases = _make_cases()
+    fn = _scripted_classifier({c.prompt: c.expected for c in cases})
+    report: ClassifyEvalReport = ClassifyEvalRunner(classifier=fn).run(cases)
+    payload = json.loads(report.to_json())
+    assert payload["accuracy"] == 1.0
+    assert "fast" in payload["per_intent"]
+    assert payload["per_intent"]["fast"]["precision"] == 1.0
+
+
+def test_format_report_includes_misclassified_rows() -> None:
+    cases = [
+        GoldenCase(prompt="p1", expected="fast"),
+        GoldenCase(prompt="p2", expected="deep"),
+    ]
+    fn = _scripted_classifier({"p1": "deep", "p2": "deep"})
+    report = ClassifyEvalRunner(classifier=fn).run(cases)
+    text = format_report(report)
+    assert "accuracy:" in text
+    assert "misclassified:" in text
+    assert "expected=fast" in text
+
+
+def test_format_report_omits_misclassified_section_when_perfect() -> None:
+    cases = [GoldenCase(prompt="p1", expected="fast")]
+    fn = _scripted_classifier({"p1": "fast"})
+    report = ClassifyEvalRunner(classifier=fn).run(cases)
+    text = format_report(report)
+    assert "misclassified:" not in text
+
+
+def test_cli_main_prints_text_report(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "g.jsonl"
+    suite.write_text(
+        json.dumps({"prompt": "what's the status?", "expected": "status"}) + "\n",
+        encoding="utf-8",
+    )
+
+    rc = main(["--suite", str(suite)])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "accuracy:" in out
+
+
+def test_cli_main_emits_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    suite = tmp_path / "g.jsonl"
+    suite.write_text(
+        json.dumps({"prompt": "what's the status?", "expected": "status"}) + "\n",
+        encoding="utf-8",
+    )
+
+    rc = main(["--suite", str(suite), "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total"] == 1
+    assert payload["accuracy"] == 1.0
+
+
+def test_cli_main_exits_nonzero_below_threshold(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "g.jsonl"
+    suite.write_text(
+        json.dumps({"prompt": "what's the status?", "expected": "fast"}) + "\n",
+        encoding="utf-8",
+    )
+
+    rc = main(["--suite", str(suite), "--min-accuracy", "0.99"])
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "below threshold" in err
+
+
+def test_cli_main_accepts_injected_classifier(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "g.jsonl"
+    suite.write_text(
+        json.dumps({"prompt": "anything", "expected": "deep"}) + "\n",
+        encoding="utf-8",
+    )
+    fn = MagicMock(return_value="deep")
+
+    rc = main(["--suite", str(suite)], classifier=fn)
+
+    assert rc == 0
+    fn.assert_called_once_with("anything")
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected"),
+    [
+        ("what is the status of x?", "status"),
+        ("research the best embeddings model", "research"),
+        ("refactor the queue worker", "deep"),
+        ("capital of France", "fast"),
+    ],
+)
+def test_stub_classifier_branches(prompt: str, expected: str) -> None:
+    assert stub_classifier(prompt) == expected
+
+
+def test_golden_dataset_balanced_and_complete() -> None:
+    cases = load_golden(GOLDEN_PATH)
+    assert len(cases) >= 30
+    counts: dict[str, int] = {}
+    for case in cases:
+        counts[case.expected] = counts.get(case.expected, 0) + 1
+    # Every classifier label must be represented.
+    for label in ("fast", "deep", "research", "status"):
+        assert counts.get(label, 0) >= 6, f"label {label} underrepresented: {counts}"


### PR DESCRIPTION
Closes #38

Acceptance Criteria met.

## Summary
- New `evals/classify/` suite with:
  - `golden.jsonl` (36 labeled prompts, 9 per intent: fast, deep, research, status, plus boundary cases like 'progress on yesterday''s deep refactor' that are actually status queries)
  - `runner.py` -- `ClassifyEvalRunner`/`run_classifier_eval` computing accuracy + per-intent precision/recall/F1 + confusion matrix + misclassified rows
  - `__main__.py` -- `python -m evals.classify --suite ... [--json] [--min-accuracy 0.9]` with non-zero exit when below threshold
- `tests/evals/test_classify_runner.py` mocks the classifier (no live LLM) and verifies the harness math, dataset balance, JSONL loader edge cases, and CLI behaviour.

## Verification
- `ruff check evals/classify tests/evals/test_classify_runner.py` -- clean
- `pytest tests/evals/test_classify_runner.py --cov=evals.classify` -- 21 passed, 100% coverage
