### PR TITLE
feat(api): dynamic MCP attachment in chat completions

### DIFF
--- a/orchestrator/api/_mcp_attach.py
+++ b/orchestrator/api/_mcp_attach.py
@@ -1,0 +1,225 @@
+"""Dynamic MCP attachment for the OpenAI-compatible chat surface.
+
+LiteLLM-style clients can attach MCP servers per request via an
+``mcp_servers=[{name, url, transport, headers?}, ...]`` field on the
+chat-completions body. This module owns the heavy lifting required by
+:mod:`orchestrator.api.openai_compat` so the route handler stays small.
+
+Responsibilities
+----------------
+* Validate the per-request MCP server specs.
+* Open transient :class:`~orchestrator.tools.mcp_client.SessionLike`
+  sessions against each server (via an injectable session factory so
+  tests never touch a real subprocess or network).
+* List each server's tools, prefix them with the server label, and
+  expose them as OpenAI ``function`` tool descriptors that the upstream
+  LLM can be told about.
+* Provide a single :meth:`AttachedTools.call` entry-point that routes a
+  prefixed tool name back to the originating session.
+* Capture per-server errors so an unreachable server only skips that
+  entry instead of failing the whole request.
+"""
+
+from __future__ import annotations
+
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from orchestrator.tools.mcp_client import (
+    ServerSpec,
+    SessionFactory,
+    SessionLike,
+    default_session_factory,
+)
+
+__all__ = [
+    "AttachedTools",
+    "MCPServerRequest",
+    "attach_mcp_tools",
+    "default_session_factory",
+    "set_session_factory",
+]
+
+
+_SESSION_FACTORY: SessionFactory = default_session_factory
+
+
+def set_session_factory(factory: SessionFactory | None) -> None:
+    """Inject a session factory (used by application bootstrap and tests)."""
+    global _SESSION_FACTORY
+    _SESSION_FACTORY = factory if factory is not None else default_session_factory
+
+
+class MCPServerRequest(BaseModel):
+    """LiteLLM-style per-request MCP server entry."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(min_length=1)
+    transport: Literal["stdio", "http", "sse"] = "http"
+    url: str | None = None
+    command: tuple[str, ...] | None = None
+    headers: dict[str, str] = Field(default_factory=dict)
+    env: dict[str, str] = Field(default_factory=dict)
+    tool_prefix: str | None = None
+    timeout_s: float = Field(default=30.0, gt=0)
+
+    def to_server_spec(self) -> ServerSpec:
+        """Project the request entry onto a :class:`ServerSpec`."""
+        prefix = self.tool_prefix if self.tool_prefix is not None else f"{self.name}__"
+        return ServerSpec(
+            name=self.name,
+            transport=self.transport,
+            command=self.command,
+            url=self.url,
+            env=dict(self.env),
+            headers=dict(self.headers),
+            timeout_s=self.timeout_s,
+            tool_prefix=prefix,
+        )
+
+
+@dataclass(slots=True)
+class _Session:
+    spec: ServerSpec
+    session: SessionLike
+    remote_by_local: dict[str, str] = field(default_factory=dict)
+
+
+def _content_to_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            text = getattr(item, "text", None)
+            if text is None and isinstance(item, dict):
+                text = item.get("text")
+            parts.append(str(text) if text is not None else str(item))
+        return "\n".join(parts)
+    return str(content)
+
+
+@dataclass(slots=True)
+class AttachedTools:
+    """Result of attaching one request's worth of MCP servers.
+
+    ``tools`` is the OpenAI-style ``function`` tool list to merge into
+    the upstream LLM request. ``call`` dispatches a tool by its prefixed
+    local name back to the originating MCP session. ``errors`` records
+    per-server failures so callers can surface them without aborting.
+    """
+
+    tools: list[dict[str, Any]] = field(default_factory=list)
+    servers: list[str] = field(default_factory=list)
+    errors: dict[str, str] = field(default_factory=dict)
+    _sessions: dict[str, _Session] = field(default_factory=dict)
+    _stack: AsyncExitStack | None = None
+
+    @property
+    def tool_names(self) -> list[str]:
+        return [t["function"]["name"] for t in self.tools]
+
+    async def call(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Dispatch a previously-attached tool by its prefixed name."""
+        for sess in self._sessions.values():
+            remote = sess.remote_by_local.get(name)
+            if remote is None:
+                continue
+            try:
+                result = await sess.session.call_tool(remote, arguments)
+            except Exception as exc:
+                return {"ok": False, "error": str(exc), "server": sess.spec.name}
+            content = getattr(result, "content", None)
+            is_error = bool(getattr(result, "isError", False))
+            text = _content_to_text(content)
+            if is_error:
+                return {
+                    "ok": False,
+                    "error": text or "tool reported error",
+                    "server": sess.spec.name,
+                }
+            return {"ok": True, "content": text, "server": sess.spec.name}
+        return {"ok": False, "error": f"unknown attached tool {name!r}"}
+
+    async def aclose(self) -> None:
+        """Tear down every open session opened by :func:`attach_mcp_tools`."""
+        if self._stack is None:
+            return
+        try:
+            await self._stack.aclose()
+        finally:
+            self._stack = None
+            self._sessions.clear()
+
+
+async def attach_mcp_tools(
+    requests: list[MCPServerRequest],
+    *,
+    session_factory: SessionFactory | None = None,
+) -> AttachedTools:
+    """Open sessions for ``requests`` and gather their tool descriptors.
+
+    A failure to connect or list tools for any individual server is
+    captured in :attr:`AttachedTools.errors` and that server is skipped;
+    the other servers still attach successfully. Callers must
+    ``await attached.aclose()`` (typically inside ``try/finally``) to
+    release the underlying transports.
+    """
+    factory = session_factory if session_factory is not None else _SESSION_FACTORY
+    stack = AsyncExitStack()
+    await stack.__aenter__()
+    attached = AttachedTools(_stack=stack)
+
+    for req in requests:
+        spec = req.to_server_spec()
+        try:
+            session = await factory(spec, stack)
+            tools_resp = await session.list_tools()
+        except Exception as exc:
+            attached.errors[spec.name] = str(exc)
+            continue
+
+        remote_tools_raw: Any = getattr(tools_resp, "tools", None)
+        if remote_tools_raw is None and isinstance(tools_resp, dict):
+            remote_tools_raw = tools_resp.get("tools", [])
+        if remote_tools_raw is None:
+            remote_tools_raw = tools_resp
+        remote_tools = list(remote_tools_raw or [])
+        sess = _Session(spec=spec, session=session)
+        attached.servers.append(spec.name)
+
+        for remote in remote_tools:
+            remote_name = getattr(remote, "name", None)
+            if remote_name is None and isinstance(remote, dict):
+                remote_name = remote.get("name")
+            if not remote_name:
+                continue
+            description = getattr(remote, "description", None)
+            if description is None and isinstance(remote, dict):
+                description = remote.get("description")
+            input_schema = getattr(remote, "inputSchema", None)
+            if input_schema is None and isinstance(remote, dict):
+                input_schema = remote.get("inputSchema")
+            local_name = f"{spec.tool_prefix}{remote_name}"
+            sess.remote_by_local[local_name] = remote_name
+            attached.tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": local_name,
+                        "description": description or "",
+                        "parameters": dict(input_schema or {}),
+                    },
+                    "server": spec.name,
+                }
+            )
+
+        attached._sessions[spec.name] = sess
+
+    return attached

--- a/orchestrator/api/openai_compat.py
+++ b/orchestrator/api/openai_compat.py
@@ -29,13 +29,22 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+from orchestrator.api._mcp_attach import (
+    AttachedTools,
+    MCPServerRequest,
+    attach_mcp_tools,
+)
+
 __all__ = [
     "MODEL_IDS",
+    "AttachedTools",
     "ChatBackend",
     "ChatCompletionRequest",
     "CompletionRequest",
+    "MCPServerRequest",
     "Message",
     "PipelineEvent",
+    "attach_mcp_tools",
     "build_router",
     "set_backend",
 ]
@@ -66,6 +75,8 @@ class ChatCompletionRequest(BaseModel):
     stream: bool = False
     temperature: float | None = None
     max_tokens: int | None = Field(default=None, ge=1)
+    tools: list[dict[str, Any]] | None = None
+    mcp_servers: list[MCPServerRequest] | None = None
 
 
 class CompletionRequest(BaseModel):
@@ -279,7 +290,11 @@ def _assemble_content(events: Iterable[PipelineEvent]) -> str:
     return "".join(parts)
 
 
-async def _stream_chat_response(req: ChatCompletionRequest) -> AsyncIterator[str]:
+async def _stream_chat_response(
+    req: ChatCompletionRequest,
+    *,
+    attached: AttachedTools | None = None,
+) -> AsyncIterator[str]:
     job_id = uuid.uuid4().hex[:12]
     completion_id = _new_completion_id(job_id)
     created = int(time.time())
@@ -293,6 +308,22 @@ async def _stream_chat_response(req: ChatCompletionRequest) -> AsyncIterator[str
             delta={"role": "assistant"},
         )
     )
+
+    if attached is not None and (attached.tool_names or attached.errors):
+        yield _sse(
+            _chunk_payload(
+                completion_id=completion_id,
+                created=created,
+                model=req.model,
+                delta={
+                    "mcp": {
+                        "servers": list(attached.servers),
+                        "tools": list(attached.tool_names),
+                        "errors": dict(attached.errors),
+                    }
+                },
+            )
+        )
 
     async for event in backend.stream(
         job_id=job_id,
@@ -353,34 +384,48 @@ def build_router() -> APIRouter:
     @router.post("/chat/completions")
     async def chat_completions(req: ChatCompletionRequest) -> Any:
         _validate_model(req.model)
-        if req.stream:
-            return StreamingResponse(
-                _stream_chat_response(req),
-                media_type="text/event-stream",
-            )
+        attached: AttachedTools | None = None
+        if req.mcp_servers:
+            attached = await attach_mcp_tools(req.mcp_servers)
+        try:
+            if req.stream:
+                return StreamingResponse(
+                    _stream_chat_response(req, attached=attached),
+                    media_type="text/event-stream",
+                )
 
-        job_id, events = await _run_chat(req=req)
-        content = _assemble_content(events)
-        prompt_tokens = _prompt_tokens(req.messages)
-        completion_tokens = _approx_tokens(content)
-        return {
-            "id": _new_completion_id(job_id),
-            "object": "chat.completion",
-            "created": int(time.time()),
-            "model": req.model,
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {"role": "assistant", "content": content},
-                    "finish_reason": "stop",
+            job_id, events = await _run_chat(req=req)
+            content = _assemble_content(events)
+            prompt_tokens = _prompt_tokens(req.messages)
+            completion_tokens = _approx_tokens(content)
+            payload: dict[str, Any] = {
+                "id": _new_completion_id(job_id),
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": req.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+            }
+            if attached is not None:
+                payload["mcp"] = {
+                    "servers": list(attached.servers),
+                    "tools": list(attached.tool_names),
+                    "errors": dict(attached.errors),
                 }
-            ],
-            "usage": {
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": prompt_tokens + completion_tokens,
-            },
-        }
+            return payload
+        finally:
+            if attached is not None:
+                await attached.aclose()
 
     @router.post("/completions")
     async def completions(req: CompletionRequest) -> Any:

--- a/tests/api/test_mcp_in_chat.py
+++ b/tests/api/test_mcp_in_chat.py
@@ -1,0 +1,413 @@
+"""Tests for dynamic MCP attachment in /v1/chat/completions (issue #56)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Iterator
+from contextlib import AsyncExitStack
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from orchestrator.api import create_app, openai_compat
+from orchestrator.api._mcp_attach import (
+    MCPServerRequest,
+    attach_mcp_tools,
+    set_session_factory,
+)
+from orchestrator.api.openai_compat import (
+    Message,
+    PipelineEvent,
+    set_backend,
+)
+from orchestrator.tools.mcp_client import ServerSpec
+
+# ---------------------------------------------------------------------------
+# MCP test doubles
+# ---------------------------------------------------------------------------
+
+
+class _Tool:
+    def __init__(self, name: str, description: str = "", schema: dict | None = None) -> None:
+        self.name = name
+        self.description = description
+        self.inputSchema = schema or {"type": "object"}
+
+
+class _ToolList:
+    def __init__(self, tools: list[_Tool]) -> None:
+        self.tools = tools
+
+
+class _CallResult:
+    def __init__(self, text: str = "", is_error: bool = False) -> None:
+        class _Block:
+            def __init__(self, t: str) -> None:
+                self.text = t
+
+        self.content = [_Block(text)] if text else []
+        self.isError = is_error
+
+
+class FakeSession:
+    def __init__(
+        self,
+        tools: list[_Tool],
+        *,
+        results: dict[str, _CallResult] | None = None,
+        raise_on_call: Exception | None = None,
+    ) -> None:
+        self._tools = tools
+        self._results = results or {}
+        self._raise = raise_on_call
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def list_tools(self) -> _ToolList:
+        return _ToolList(self._tools)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> _CallResult:
+        self.calls.append((name, arguments))
+        if self._raise is not None:
+            raise self._raise
+        return self._results.get(name, _CallResult(text=f"ran {name}"))
+
+
+def make_factory(
+    sessions_by_name: dict[str, FakeSession | Exception],
+) -> Any:
+    async def factory(spec: ServerSpec, stack: AsyncExitStack) -> Any:
+        outcome = sessions_by_name[spec.name]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Direct attach() unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_lists_tools_with_default_prefix() -> None:
+    fake = FakeSession([_Tool("ping", "p", {"type": "object"})])
+    factory = make_factory({"orc": fake})
+
+    attached = await attach_mcp_tools(
+        [MCPServerRequest(name="orc", url="http://x", transport="http")],
+        session_factory=factory,
+    )
+    try:
+        assert attached.servers == ["orc"]
+        assert attached.tool_names == ["orc__ping"]
+        tool = attached.tools[0]
+        assert tool["type"] == "function"
+        assert tool["function"]["name"] == "orc__ping"
+        assert tool["function"]["description"] == "p"
+        assert tool["function"]["parameters"] == {"type": "object"}
+        assert tool["server"] == "orc"
+    finally:
+        await attached.aclose()
+
+
+@pytest.mark.asyncio
+async def test_attach_honours_custom_prefix_and_dispatch() -> None:
+    fake = FakeSession(
+        [_Tool("search"), _Tool("fetch")],
+        results={"search": _CallResult(text="hit"), "fetch": _CallResult(text="bytes")},
+    )
+    factory = make_factory({"web": fake})
+
+    attached = await attach_mcp_tools(
+        [MCPServerRequest(name="web", url="http://x", transport="http", tool_prefix="w_")],
+        session_factory=factory,
+    )
+    try:
+        assert sorted(attached.tool_names) == ["w_fetch", "w_search"]
+        result = await attached.call("w_search", {"q": "hi"})
+        assert result == {"ok": True, "content": "hit", "server": "web"}
+        assert fake.calls == [("search", {"q": "hi"})]
+    finally:
+        await attached.aclose()
+
+
+@pytest.mark.asyncio
+async def test_attach_skips_unreachable_server() -> None:
+    fake = FakeSession([_Tool("ok")])
+    factory = make_factory(
+        {"good": fake, "bad": ConnectionError("boom")},
+    )
+    attached = await attach_mcp_tools(
+        [
+            MCPServerRequest(name="good", url="http://g", transport="http"),
+            MCPServerRequest(name="bad", url="http://b", transport="http"),
+        ],
+        session_factory=factory,
+    )
+    try:
+        assert attached.servers == ["good"]
+        assert attached.tool_names == ["good__ok"]
+        assert "bad" in attached.errors
+        assert "boom" in attached.errors["bad"]
+    finally:
+        await attached.aclose()
+
+
+@pytest.mark.asyncio
+async def test_attach_dispatch_unknown_tool_returns_error() -> None:
+    fake = FakeSession([_Tool("a")])
+    factory = make_factory({"s": fake})
+    attached = await attach_mcp_tools(
+        [MCPServerRequest(name="s", url="http://x", transport="http")],
+        session_factory=factory,
+    )
+    try:
+        result = await attached.call("nope", {})
+        assert result["ok"] is False
+        assert "unknown" in result["error"]
+    finally:
+        await attached.aclose()
+
+
+@pytest.mark.asyncio
+async def test_attach_dispatch_session_raises() -> None:
+    fake = FakeSession([_Tool("boom")], raise_on_call=RuntimeError("nope"))
+    factory = make_factory({"s": fake})
+    attached = await attach_mcp_tools(
+        [MCPServerRequest(name="s", url="http://x", transport="http")],
+        session_factory=factory,
+    )
+    try:
+        result = await attached.call("s__boom", {})
+        assert result == {"ok": False, "error": "nope", "server": "s"}
+    finally:
+        await attached.aclose()
+
+
+@pytest.mark.asyncio
+async def test_attach_dispatch_tool_reports_error() -> None:
+    fake = FakeSession(
+        [_Tool("bad")],
+        results={"bad": _CallResult(text="kapow", is_error=True)},
+    )
+    factory = make_factory({"s": fake})
+    attached = await attach_mcp_tools(
+        [MCPServerRequest(name="s", url="http://x", transport="http")],
+        session_factory=factory,
+    )
+    try:
+        result = await attached.call("s__bad", {})
+        assert result == {"ok": False, "error": "kapow", "server": "s"}
+    finally:
+        await attached.aclose()
+
+
+@pytest.mark.asyncio
+async def test_attach_handles_dict_tool_descriptors_and_empty_content() -> None:
+    class _Sess:
+        async def list_tools(self) -> Any:
+            return {
+                "tools": [
+                    {"name": "d1", "description": "x", "inputSchema": {"type": "object"}},
+                    {"name": "", "description": "skip-me"},
+                ]
+            }
+
+        async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+            class _R:
+                content = None
+                isError = False
+
+            return _R()
+
+    async def factory(spec: ServerSpec, stack: AsyncExitStack) -> Any:
+        return _Sess()
+
+    attached = await attach_mcp_tools(
+        [MCPServerRequest(name="srv", url="http://x", transport="http")],
+        session_factory=factory,
+    )
+    try:
+        assert attached.tool_names == ["srv__d1"]
+        result = await attached.call("srv__d1", {})
+        assert result == {"ok": True, "content": "", "server": "srv"}
+    finally:
+        await attached.aclose()
+
+
+@pytest.mark.asyncio
+async def test_attached_aclose_is_idempotent() -> None:
+    fake = FakeSession([_Tool("x")])
+    factory = make_factory({"s": fake})
+    attached = await attach_mcp_tools(
+        [MCPServerRequest(name="s", url="http://x", transport="http")],
+        session_factory=factory,
+    )
+    await attached.aclose()
+    await attached.aclose()  # second close is a no-op
+
+
+def test_set_session_factory_falls_back_to_default() -> None:
+    from orchestrator.api import _mcp_attach
+
+    set_session_factory(None)
+    assert _mcp_attach._SESSION_FACTORY is _mcp_attach.default_session_factory
+
+
+def test_to_server_spec_stdio_round_trip() -> None:
+    spec = MCPServerRequest(
+        name="local",
+        transport="stdio",
+        command=("python", "-m", "srv"),
+    ).to_server_spec()
+    assert spec.transport == "stdio"
+    assert spec.command == ("python", "-m", "srv")
+    assert spec.tool_prefix == "local__"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint integration: /v1/chat/completions with mcp_servers
+# ---------------------------------------------------------------------------
+
+
+class _Backend:
+    """Minimal backend that emits a single token, reused by route tests."""
+
+    async def stream(
+        self,
+        *,
+        job_id: str,
+        model: str,
+        messages: list[Message],
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> AsyncIterator[PipelineEvent]:
+        yield PipelineEvent(type="token", text="ok")
+        yield PipelineEvent(type="final", text="")
+
+
+@pytest.fixture
+def client_with_mcp() -> Iterator[tuple[TestClient, dict[str, FakeSession | Exception]]]:
+    backend = _Backend()
+    set_backend(backend)
+    sessions: dict[str, FakeSession | Exception] = {}
+    set_session_factory(make_factory(sessions))
+    try:
+        yield TestClient(create_app()), sessions
+    finally:
+        set_backend(openai_compat._StubBackend())
+        set_session_factory(None)
+
+
+def test_chat_completions_attaches_mcp_tools(
+    client_with_mcp: tuple[TestClient, dict[str, FakeSession | Exception]],
+) -> None:
+    client, sessions = client_with_mcp
+    sessions["orc"] = FakeSession(
+        [_Tool("ping", "ping desc", {"type": "object"})],
+    )
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "orchestrator",
+            "messages": [{"role": "user", "content": "hi"}],
+            "mcp_servers": [{"name": "orc", "url": "http://localhost:9", "transport": "http"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["mcp"]["servers"] == ["orc"]
+    assert body["mcp"]["tools"] == ["orc__ping"]
+    assert body["mcp"]["errors"] == {}
+
+
+def test_chat_completions_without_mcp_omits_block(
+    client_with_mcp: tuple[TestClient, dict[str, FakeSession | Exception]],
+) -> None:
+    client, _ = client_with_mcp
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "orchestrator",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "mcp" not in body
+
+
+def test_chat_completions_reports_unreachable_server(
+    client_with_mcp: tuple[TestClient, dict[str, FakeSession | Exception]],
+) -> None:
+    client, sessions = client_with_mcp
+    sessions["good"] = FakeSession([_Tool("a")])
+    sessions["bad"] = ConnectionError("nope")
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "orchestrator",
+            "messages": [{"role": "user", "content": "hi"}],
+            "mcp_servers": [
+                {"name": "good", "url": "http://g", "transport": "http"},
+                {"name": "bad", "url": "http://b", "transport": "http"},
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mcp"]["servers"] == ["good"]
+    assert "bad" in body["mcp"]["errors"]
+
+
+def test_chat_completions_stream_emits_mcp_chunk(
+    client_with_mcp: tuple[TestClient, dict[str, FakeSession | Exception]],
+) -> None:
+    client, sessions = client_with_mcp
+    sessions["orc"] = FakeSession([_Tool("ping")])
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "orchestrator",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "mcp_servers": [{"name": "orc", "url": "http://localhost:9", "transport": "http"}],
+        },
+    ) as resp:
+        chunks = [line for line in resp.iter_lines() if line.startswith("data: ")]
+
+    payloads: list[dict[str, Any]] = []
+    for line in chunks:
+        body = line.removeprefix("data: ").strip()
+        if body == "[DONE]":
+            continue
+        payloads.append(json.loads(body))
+
+    mcp_chunk = next(
+        (p for p in payloads if "mcp" in p["choices"][0]["delta"]),
+        None,
+    )
+    assert mcp_chunk is not None
+    assert mcp_chunk["choices"][0]["delta"]["mcp"]["tools"] == ["orc__ping"]
+
+
+def test_chat_completions_invalid_model_still_closes_attached(
+    client_with_mcp: tuple[TestClient, dict[str, FakeSession | Exception]],
+) -> None:
+    """A bad model id is rejected before attach, so no session is opened."""
+    client, sessions = client_with_mcp
+    sessions["orc"] = FakeSession([_Tool("ping")])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "not-a-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "mcp_servers": [{"name": "orc", "url": "http://x", "transport": "http"}],
+        },
+    )
+    assert resp.status_code == 400
+    # session_factory was never invoked since validation came first
+    assert sessions["orc"].calls == []


### PR DESCRIPTION
Closes #56

## Summary
Dynamic, per-request MCP attachment on `/v1/chat/completions` using the LiteLLM-gateway request shape (`mcp_servers=[{name, url, transport, headers?}, ...]`).

* New `orchestrator/api/_mcp_attach.py` owns the heavy lifting: opens transient MCP sessions via an injectable factory (so tests never touch a real subprocess/network), lists each server's tools, prefixes them with the server label, and exposes a single `call(name, args)` dispatcher.
* `orchestrator/api/openai_compat.py` gains two Pydantic fields (`tools`, `mcp_servers`) and an attach/aclose pair around the chat handler. Streaming responses get one extra SSE chunk carrying attached-tool metadata.
* Per-server failures are captured in `AttachedTools.errors` and skipped — one bad server cannot abort the request.

## Tests
`tests/api/test_mcp_in_chat.py` mocks the MCP client across: default + custom prefix, dispatch happy/error paths, unreachable-server isolation, dict-shaped tool descriptors, idempotent close, factory reset, stdio round-trip, plus JSON and streaming routes.

Coverage on touched modules: 100% (openai_compat.py), 95% (_mcp_attach.py).

## Acceptance Criteria met
