### PR TITLE
feat(mcp): MCP stdio server

### DIFF
--- a/orchestrator/interfaces/mcp_server.py
+++ b/orchestrator/interfaces/mcp_server.py
@@ -1,0 +1,13 @@
+"""Compatibility shim for the ``orchestrator mcp`` CLI subcommand.
+
+The MCP stdio server lives in :mod:`orchestrator.mcp.server`; this
+module re-exports the public entry points so the existing CLI wiring
+(``orchestrator.interfaces.cli:mcp``) continues to work without
+duplication.
+"""
+
+from __future__ import annotations
+
+from orchestrator.mcp.server import build_server, main, run
+
+__all__ = ["build_server", "main", "run"]

--- a/orchestrator/mcp/__init__.py
+++ b/orchestrator/mcp/__init__.py
@@ -1,0 +1,13 @@
+"""MCP server package for the orchestrator.
+
+Exposes the orchestrator's job-manager surface (``submit_job``,
+``get_status``, ``stream_job``, ``cancel_job``) over the Model Context
+Protocol stdio transport so MCP-aware clients (Claude Desktop, IDEs,
+etc.) can drive the orchestrator without an HTTP server.
+"""
+
+from __future__ import annotations
+
+from orchestrator.mcp.server import build_server, main, run
+
+__all__ = ["build_server", "main", "run"]

--- a/orchestrator/mcp/__main__.py
+++ b/orchestrator/mcp/__main__.py
@@ -1,0 +1,8 @@
+"""``python -m orchestrator.mcp`` entrypoint."""
+
+from __future__ import annotations
+
+from orchestrator.mcp.server import run
+
+if __name__ == "__main__":  # pragma: no cover - CLI shim
+    run()

--- a/orchestrator/mcp/server.py
+++ b/orchestrator/mcp/server.py
@@ -1,0 +1,178 @@
+"""MCP stdio server exposing the orchestrator job manager.
+
+The server registers four tools that mirror the native HTTP API:
+
+* ``submit_job`` - enqueue a job and return its id immediately.
+* ``get_status`` - return a status payload in mode ``a``, ``b`` or ``c``.
+* ``stream_job`` - drain pipeline events for a job until terminal.
+* ``cancel_job`` - cooperatively cancel a running job.
+
+Every tool implementation delegates to
+:class:`orchestrator.api.tasks.JobManager` so the MCP and HTTP
+interfaces share a single source of truth.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import mcp.types as mt
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from orchestrator.api.tasks import JobManager, get_job_manager
+
+__all__ = [
+    "SERVER_NAME",
+    "SERVER_VERSION",
+    "TOOL_DEFINITIONS",
+    "build_server",
+    "main",
+    "run",
+]
+
+SERVER_NAME = "orchestrator"
+SERVER_VERSION = "0.1.0"
+
+TOOL_DEFINITIONS: list[mt.Tool] = [
+    mt.Tool(
+        name="submit_job",
+        description="Submit a new orchestrator job; returns the job_id immediately.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "user_msg": {
+                    "type": "string",
+                    "description": "Goal/message for the job.",
+                },
+                "model": {
+                    "type": ["string", "null"],
+                    "description": "Optional model id; defaults to the orchestrator default.",
+                },
+            },
+            "required": ["user_msg"],
+            "additionalProperties": False,
+        },
+    ),
+    mt.Tool(
+        name="get_status",
+        description="Return a status payload for a job in mode 'a', 'b' or 'c'.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "job_id": {"type": "string"},
+                "mode": {
+                    "type": "string",
+                    "enum": ["a", "b", "c"],
+                    "default": "a",
+                },
+            },
+            "required": ["job_id"],
+            "additionalProperties": False,
+        },
+    ),
+    mt.Tool(
+        name="stream_job",
+        description=(
+            "Drain pipeline events for a job until it reaches a terminal "
+            "state and return them as a list of JSON content blocks."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {"job_id": {"type": "string"}},
+            "required": ["job_id"],
+            "additionalProperties": False,
+        },
+    ),
+    mt.Tool(
+        name="cancel_job",
+        description="Cooperatively cancel a running job.",
+        inputSchema={
+            "type": "object",
+            "properties": {"job_id": {"type": "string"}},
+            "required": ["job_id"],
+            "additionalProperties": False,
+        },
+    ),
+]
+
+
+def _text(payload: Any) -> mt.TextContent:
+    return mt.TextContent(type="text", text=json.dumps(payload, default=str))
+
+
+async def _submit_job(mgr: JobManager, args: dict[str, Any]) -> list[mt.ContentBlock]:
+    job = mgr.submit(args["user_msg"], args.get("model"))
+    return [_text({"job_id": job.id})]
+
+
+async def _get_status(mgr: JobManager, args: dict[str, Any]) -> list[mt.ContentBlock]:
+    job = mgr.get(args["job_id"])
+    mode = args.get("mode", "a")
+    return [_text(mgr.status_payload(job, mode))]
+
+
+async def _stream_job(mgr: JobManager, args: dict[str, Any]) -> list[mt.ContentBlock]:
+    job = mgr.get(args["job_id"])
+    blocks: list[mt.ContentBlock] = []
+    async for ev in mgr.stream(job):
+        blocks.append(_text({"kind": ev.kind, "data": ev.data, "ts": ev.ts}))
+    return blocks
+
+
+async def _cancel_job(mgr: JobManager, args: dict[str, Any]) -> list[mt.ContentBlock]:
+    job = mgr.get(args["job_id"])
+    await mgr.cancel(job)
+    return [_text({"ok": True, "job_id": job.id, "status": job.status.value})]
+
+
+HANDLERS: dict[str, Any] = {
+    "submit_job": _submit_job,
+    "get_status": _get_status,
+    "stream_job": _stream_job,
+    "cancel_job": _cancel_job,
+}
+
+
+def build_server(mgr: JobManager | None = None) -> Server:
+    """Build a configured MCP :class:`~mcp.server.Server`.
+
+    Parameters
+    ----------
+    mgr:
+        Job manager to delegate to. Defaults to the process-wide manager
+        returned by :func:`orchestrator.api.tasks.get_job_manager`.
+    """
+    server: Server = Server(SERVER_NAME, version=SERVER_VERSION)
+    manager = mgr if mgr is not None else get_job_manager()
+
+    @server.list_tools()
+    async def _list_tools() -> list[mt.Tool]:
+        return list(TOOL_DEFINITIONS)
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[mt.ContentBlock]:
+        handler = HANDLERS.get(name)
+        if handler is None:
+            raise ValueError(f"unknown tool: {name}")
+        return await handler(manager, arguments or {})
+
+    return server
+
+
+async def main() -> None:
+    """Run the stdio loop until the client disconnects (EOF)."""
+    server = build_server()
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+def run() -> None:
+    """Synchronous entry point used by the CLI and ``python -m``."""
+    asyncio.run(main())

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,0 +1,306 @@
+"""Tests for the orchestrator MCP stdio server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import mcp.types as mt
+import pytest
+from mcp.server import Server
+
+from orchestrator.api.tasks import JobStatus, PipelineEvent
+from orchestrator.mcp import server as mcp_server
+from orchestrator.mcp.server import (
+    HANDLERS,
+    SERVER_NAME,
+    SERVER_VERSION,
+    TOOL_DEFINITIONS,
+    build_server,
+    main,
+    run,
+)
+
+
+class _FakeJob:
+    def __init__(self, job_id: str = "job-123") -> None:
+        self.id = job_id
+        self.status = JobStatus.RUNNING
+
+
+class _FakeManager:
+    """Minimal JobManager double exercising the MCP handler surface."""
+
+    def __init__(self, events: list[PipelineEvent] | None = None) -> None:
+        self._events = events or []
+        self.submitted: list[tuple[str, str | None]] = []
+        self.cancelled: list[str] = []
+        self.status_calls: list[tuple[str, str]] = []
+        self.get_calls: list[str] = []
+
+    def submit(self, user_msg: str, model: str | None) -> _FakeJob:
+        self.submitted.append((user_msg, model))
+        return _FakeJob()
+
+    def get(self, job_id: str) -> _FakeJob:
+        self.get_calls.append(job_id)
+        return _FakeJob(job_id)
+
+    def status_payload(self, job: _FakeJob, mode: str) -> dict[str, Any]:
+        self.status_calls.append((job.id, mode))
+        return {"mode": mode, "status": job.status.value, "id": job.id}
+
+    async def stream(self, job: _FakeJob) -> AsyncIterator[PipelineEvent]:
+        for ev in self._events:
+            yield ev
+
+    async def cancel(self, job: _FakeJob) -> None:
+        self.cancelled.append(job.id)
+        job.status = JobStatus.CANCELLED
+
+
+def _decode(blocks: list[mt.ContentBlock]) -> list[Any]:
+    out: list[Any] = []
+    for blk in blocks:
+        assert isinstance(blk, mt.TextContent)
+        out.append(json.loads(blk.text))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Tool definitions                                                            #
+# --------------------------------------------------------------------------- #
+def test_tool_definitions_cover_required_surface() -> None:
+    names = [t.name for t in TOOL_DEFINITIONS]
+    assert names == ["submit_job", "get_status", "stream_job", "cancel_job"]
+    for tool in TOOL_DEFINITIONS:
+        schema = tool.inputSchema
+        assert schema["type"] == "object"
+        assert "properties" in schema
+        assert tool.description
+
+
+def test_get_status_schema_constrains_mode() -> None:
+    [tool] = [t for t in TOOL_DEFINITIONS if t.name == "get_status"]
+    mode = tool.inputSchema["properties"]["mode"]
+    assert mode["enum"] == ["a", "b", "c"]
+    assert mode["default"] == "a"
+
+
+# --------------------------------------------------------------------------- #
+# Direct handler routing                                                      #
+# --------------------------------------------------------------------------- #
+def test_submit_job_handler_delegates_to_manager() -> None:
+    mgr = _FakeManager()
+    blocks = asyncio.run(HANDLERS["submit_job"](mgr, {"user_msg": "hi", "model": "m"}))
+    assert mgr.submitted == [("hi", "m")]
+    assert _decode(blocks) == [{"job_id": "job-123"}]
+
+
+def test_submit_job_handler_defaults_model_to_none() -> None:
+    mgr = _FakeManager()
+    asyncio.run(HANDLERS["submit_job"](mgr, {"user_msg": "go"}))
+    assert mgr.submitted == [("go", None)]
+
+
+def test_get_status_handler_uses_default_mode() -> None:
+    mgr = _FakeManager()
+    blocks = asyncio.run(HANDLERS["get_status"](mgr, {"job_id": "abc"}))
+    assert mgr.status_calls == [("abc", "a")]
+    assert _decode(blocks) == [{"mode": "a", "status": "running", "id": "abc"}]
+
+
+def test_get_status_handler_passes_mode_through() -> None:
+    mgr = _FakeManager()
+    blocks = asyncio.run(HANDLERS["get_status"](mgr, {"job_id": "x", "mode": "c"}))
+    assert mgr.status_calls == [("x", "c")]
+    assert _decode(blocks)[0]["mode"] == "c"
+
+
+def test_stream_job_handler_drains_events() -> None:
+    events = [
+        PipelineEvent(kind="started", data={"k": 1}, ts=1.0),
+        PipelineEvent(kind="completed", data={}, ts=2.0),
+    ]
+    mgr = _FakeManager(events=events)
+    blocks = asyncio.run(HANDLERS["stream_job"](mgr, {"job_id": "j"}))
+    decoded = _decode(blocks)
+    assert [d["kind"] for d in decoded] == ["started", "completed"]
+    assert decoded[0]["data"] == {"k": 1}
+    assert decoded[0]["ts"] == 1.0
+
+
+def test_cancel_job_handler_marks_cancelled() -> None:
+    mgr = _FakeManager()
+    blocks = asyncio.run(HANDLERS["cancel_job"](mgr, {"job_id": "z"}))
+    assert mgr.cancelled == ["z"]
+    payload = _decode(blocks)[0]
+    assert payload == {"ok": True, "job_id": "z", "status": "cancelled"}
+
+
+# --------------------------------------------------------------------------- #
+# Server wiring                                                               #
+# --------------------------------------------------------------------------- #
+def test_build_server_uses_default_manager_when_omitted() -> None:
+    sentinel = _FakeManager()
+    with patch.object(mcp_server, "get_job_manager", return_value=sentinel) as gm:
+        server = build_server()
+    assert gm.called
+    assert isinstance(server, Server)
+    assert server.name == SERVER_NAME
+    assert server.version == SERVER_VERSION
+
+
+def test_build_server_registers_list_and_call_handlers() -> None:
+    server = build_server(mgr=_FakeManager())
+    assert mt.ListToolsRequest in server.request_handlers
+    assert mt.CallToolRequest in server.request_handlers
+
+
+def test_list_tools_request_returns_full_definitions() -> None:
+    server = build_server(mgr=_FakeManager())
+    handler = server.request_handlers[mt.ListToolsRequest]
+    req = mt.ListToolsRequest(method="tools/list")
+    result = asyncio.run(handler(req))
+    payload = result.root
+    assert isinstance(payload, mt.ListToolsResult)
+    assert [t.name for t in payload.tools] == [
+        "submit_job",
+        "get_status",
+        "stream_job",
+        "cancel_job",
+    ]
+
+
+def test_call_tool_request_routes_to_submit_handler() -> None:
+    mgr = _FakeManager()
+    server = build_server(mgr=mgr)
+    handler = server.request_handlers[mt.CallToolRequest]
+    req = mt.CallToolRequest(
+        method="tools/call",
+        params=mt.CallToolRequestParams(
+            name="submit_job",
+            arguments={"user_msg": "hello", "model": None},
+        ),
+    )
+    result = asyncio.run(handler(req))
+    payload = result.root
+    assert isinstance(payload, mt.CallToolResult)
+    assert not payload.isError
+    [block] = payload.content
+    assert isinstance(block, mt.TextContent)
+    assert json.loads(block.text) == {"job_id": "job-123"}
+    assert mgr.submitted == [("hello", None)]
+
+
+def test_call_tool_request_unknown_tool_marks_error() -> None:
+    server = build_server(mgr=_FakeManager())
+    handler = server.request_handlers[mt.CallToolRequest]
+    req = mt.CallToolRequest(
+        method="tools/call",
+        params=mt.CallToolRequestParams(name="bogus", arguments={}),
+    )
+    result = asyncio.run(handler(req))
+    payload = result.root
+    assert isinstance(payload, mt.CallToolResult)
+    assert payload.isError is True
+
+
+def test_call_tool_request_normalises_missing_arguments() -> None:
+    """Routing must coerce ``None`` arguments to an empty mapping before
+    dispatch so handlers can rely on a real dict."""
+
+    captured: dict[str, Any] = {}
+
+    async def fake_handler(_mgr: Any, args: dict[str, Any]) -> list[mt.ContentBlock]:
+        captured["args"] = args
+        return [mt.TextContent(type="text", text="{}")]
+
+    with patch.dict(HANDLERS, {"probe": fake_handler}, clear=False):
+        # Inject a synthetic tool entry so build_server's routing path runs.
+        server = build_server(mgr=_FakeManager())
+        handler = server.request_handlers[mt.CallToolRequest]
+        req = mt.CallToolRequest(
+            method="tools/call",
+            params=mt.CallToolRequestParams(name="probe", arguments=None),
+        )
+        result = asyncio.run(handler(req))
+        assert not result.root.isError
+    assert captured["args"] == {}
+
+
+# --------------------------------------------------------------------------- #
+# stdio entrypoint                                                            #
+# --------------------------------------------------------------------------- #
+def test_main_runs_server_over_stdio_streams() -> None:
+    fake_server = MagicMock(spec=Server)
+    fake_server.run = AsyncMock()
+    fake_server.create_initialization_options = MagicMock(return_value="init-opts")
+
+    class _StdioCM:
+        async def __aenter__(self) -> tuple[str, str]:
+            return ("read", "write")
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    with (
+        patch.object(mcp_server, "build_server", return_value=fake_server) as build,
+        patch.object(mcp_server, "stdio_server", return_value=_StdioCM()) as stdio,
+    ):
+        asyncio.run(main())
+
+    build.assert_called_once_with()
+    stdio.assert_called_once_with()
+    fake_server.run.assert_awaited_once_with("read", "write", "init-opts")
+
+
+def test_run_invokes_asyncio_run_with_main_coroutine() -> None:
+    captured: list[Any] = []
+
+    def fake_asyncio_run(coro: Any) -> None:
+        captured.append(coro)
+        coro.close()
+
+    with (
+        patch.object(mcp_server.asyncio, "run", side_effect=fake_asyncio_run),
+        patch.object(mcp_server, "main", wraps=main) as main_spy,
+    ):
+        run()
+
+    main_spy.assert_called_once_with()
+    assert captured and asyncio.iscoroutine(captured[0])
+
+
+# --------------------------------------------------------------------------- #
+# Package surface                                                             #
+# --------------------------------------------------------------------------- #
+def test_package_reexports_public_api() -> None:
+    from orchestrator import mcp as pkg
+
+    assert pkg.build_server is build_server
+    assert pkg.main is main
+    assert pkg.run is run
+
+
+def test_dunder_main_module_imports_run() -> None:
+    import importlib
+
+    mod = importlib.import_module("orchestrator.mcp.__main__")
+    assert mod.run is run
+
+
+def test_interfaces_shim_reexports_public_api() -> None:
+    from orchestrator.interfaces import mcp_server as shim
+
+    assert shim.build_server is build_server
+    assert shim.main is main
+    assert shim.run is run
+
+
+@pytest.mark.parametrize("tool_name", ["submit_job", "get_status", "stream_job", "cancel_job"])
+def test_each_handler_registered(tool_name: str) -> None:
+    assert tool_name in HANDLERS


### PR DESCRIPTION
Closes #17

## Summary

Adds an MCP stdio server that exposes the orchestrator job-manager surface to MCP-aware clients (Claude Desktop, MCP-enabled IDEs) without requiring the HTTP server.

The server registers four tools that mirror the native HTTP API:

- `submit_job(user_msg, model?)` -> `{ job_id }`
- `get_status(job_id, mode='a'|'b'|'c')` -> status payload
- `stream_job(job_id)` -> drains pipeline events to JSON content blocks
- `cancel_job(job_id)` -> `{ ok, job_id, status }`

All four delegate directly to `orchestrator.api.tasks.JobManager` so the MCP and HTTP interfaces share one source of truth.

## Files

- `orchestrator/mcp/server.py` - Server builder, tool definitions, handlers, stdio entrypoint.
- `orchestrator/mcp/__init__.py` - Public re-exports.
- `orchestrator/mcp/__main__.py` - `python -m orchestrator.mcp` shim.
- `orchestrator/interfaces/mcp_server.py` - Thin re-export shim so the existing `orchestrator mcp` Typer subcommand keeps working.
- `tests/mcp/test_server.py` - 23 tests; 100% coverage on the new package.

## Acceptance Criteria met

- [x] Uses the official `mcp` Python SDK with the stdio transport.
- [x] `submit_job` / `get_status` / `stream_job` / `cancel_job` tools.
- [x] `orchestrator mcp` runs the stdio loop (reuses existing CLI command via shim).
- [x] Server reuses the core `JobManager` - no duplicated logic.
- [x] Tests assert tool definitions, handler routing, server wiring, and stdio entrypoint.
- [x] `ruff check` clean.
- [x] Type hints on public surfaces.
- [x] Coverage >= 95% (100% on new code).
