### PR TITLE
feat(runtime): status mode C

### DIFF
--- a/orchestrator/runtime/status_c.py
+++ b/orchestrator/runtime/status_c.py
@@ -1,0 +1,264 @@
+"""Status mode C: queued reasoning synthesis at next checkpoint.
+
+Mode C answers "what's really going on?" by asking the resident reasoning
+model to synthesize a deeper narrative about a job's state. Per the
+architectural rule that *status queries must not require an LLM by
+default*, the public entry point :func:`status_c` returns immediately
+with the cheap mode-A :class:`~orchestrator.runtime.status.Snapshot`
+payload as a placeholder plus a ``synthesis_id`` correlator. The
+synthesized narrative is produced later, only at a safe swap point
+between coder steps, and streamed to subscribers via the SSE sink.
+
+The module is intentionally self-contained so it can land in parallel
+with other mode-B work that touches the scheduler. The
+:class:`StatusCCoordinator` exposes a small surface (queue, drain hook,
+subscribe) that the scheduler / HTTP layer can wire in without further
+coupling.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections import OrderedDict, defaultdict
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from orchestrator.runtime.status import RamReading, Snapshot, snapshot
+
+__all__ = [
+    "ReasoningModel",
+    "StatusCCoordinator",
+    "SynthesisRecord",
+    "SynthesisRequest",
+    "SynthesisResult",
+    "status_c",
+]
+
+
+class ReasoningModel(Protocol):
+    """Minimal protocol the resident reasoning model must satisfy."""
+
+    def synthesize(self, job: Any, snap: Snapshot) -> str:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass(frozen=True)
+class SynthesisRequest:
+    """A queued request to synthesize a status narrative for a job."""
+
+    job_id: str
+    synthesis_id: str
+    placeholder: Snapshot
+
+
+@dataclass(frozen=True)
+class SynthesisResult:
+    """The deferred response body produced by Mode C."""
+
+    job_id: str
+    synthesis_id: str
+    text: str
+
+
+@dataclass
+class SynthesisRecord:
+    """Persisted state for a mode-C synthesis lifecycle."""
+
+    job_id: str
+    synthesis_id: str
+    status: str = "queued"
+    placeholder: Snapshot | None = None
+    text: str | None = None
+
+
+# Type alias for an SSE-style sink: receives ``(event_type, payload)``.
+SseSink = Callable[[str, dict[str, Any]], None]
+
+
+@dataclass
+class _PendingEntry:
+    request: SynthesisRequest
+    record: SynthesisRecord
+
+
+@dataclass
+class StatusCCoordinator:
+    """Owns the synthesis queue, persistence, and SSE fan-out for mode C.
+
+    The coordinator is thread-safe enough for the orchestrator's
+    single-writer scheduler loop: enqueueing, draining, and subscribing
+    are guarded by a single lock. SSE delivery happens *outside* the
+    lock so a slow subscriber cannot stall the scheduler.
+    """
+
+    reasoning_model: ReasoningModel
+    id_factory: Callable[[], str] = field(default=lambda: uuid.uuid4().hex)
+    _pending: OrderedDict[str, _PendingEntry] = field(
+        default_factory=OrderedDict, init=False, repr=False
+    )
+    _records: dict[str, SynthesisRecord] = field(default_factory=dict, init=False, repr=False)
+    _subscribers: dict[str, list[SseSink]] = field(
+        default_factory=lambda: defaultdict(list), init=False, repr=False
+    )
+    _lock: threading.RLock = field(default_factory=threading.RLock, init=False, repr=False)
+
+    # ---- enqueue / coalesce -------------------------------------------------
+
+    def request_status_synthesis(self, job_id: str, placeholder: Snapshot) -> SynthesisRequest:
+        """Enqueue a synthesis request, coalescing duplicates per job.
+
+        If a synthesis is already pending for ``job_id``, the existing
+        :class:`SynthesisRequest` is returned unchanged so its
+        ``synthesis_id`` can be re-used by the caller.
+        """
+        with self._lock:
+            existing = self._pending.get(job_id)
+            if existing is not None:
+                return existing.request
+            req = SynthesisRequest(
+                job_id=job_id,
+                synthesis_id=self.id_factory(),
+                placeholder=placeholder,
+            )
+            record = SynthesisRecord(
+                job_id=job_id,
+                synthesis_id=req.synthesis_id,
+                status="queued",
+                placeholder=placeholder,
+            )
+            self._pending[job_id] = _PendingEntry(request=req, record=record)
+            self._records[req.synthesis_id] = record
+            return req
+
+    def pending_for(self, job_id: str) -> SynthesisRequest | None:
+        """Return the queued request for ``job_id`` if one is pending."""
+        with self._lock:
+            entry = self._pending.get(job_id)
+            return entry.request if entry is not None else None
+
+    def get_record(self, synthesis_id: str) -> SynthesisRecord | None:
+        """Return the persisted record for ``synthesis_id`` if any."""
+        with self._lock:
+            return self._records.get(synthesis_id)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._pending)
+
+    # ---- SSE fan-out --------------------------------------------------------
+
+    def subscribe(self, job_id: str, sink: SseSink) -> Callable[[], None]:
+        """Register ``sink`` for events on ``job_id`` and return an unsubscribe."""
+        with self._lock:
+            self._subscribers[job_id].append(sink)
+
+        def _unsubscribe() -> None:
+            with self._lock:
+                sinks = self._subscribers.get(job_id)
+                if not sinks:
+                    return
+                try:
+                    sinks.remove(sink)
+                except ValueError:
+                    return
+                if not sinks:
+                    del self._subscribers[job_id]
+
+        return _unsubscribe
+
+    def _emit(self, job_id: str, event_type: str, payload: dict[str, Any]) -> None:
+        with self._lock:
+            sinks = list(self._subscribers.get(job_id, ()))
+        for sink in sinks:
+            sink(event_type, payload)
+
+    # ---- drain hook ---------------------------------------------------------
+
+    def drain_post_checkpoint_hooks(
+        self, job_lookup: Callable[[str], Any]
+    ) -> list[SynthesisResult]:
+        """Drain all queued synthesis requests at a safe swap point.
+
+        Called by the scheduler *between* coder steps. For each pending
+        request, the resident reasoning model is invoked, the record is
+        marked ``done``, and a ``status_synthesis`` SSE event is emitted
+        on the job's stream. Requests whose job can no longer be
+        resolved are marked ``failed`` and skipped.
+        """
+        with self._lock:
+            drained = list(self._pending.values())
+            self._pending.clear()
+
+        results: list[SynthesisResult] = []
+        for entry in drained:
+            req = entry.request
+            record = entry.record
+            try:
+                job = job_lookup(req.job_id)
+            except KeyError:
+                job = None
+            if job is None:
+                with self._lock:
+                    record.status = "failed"
+                self._emit(
+                    req.job_id,
+                    "status_synthesis_failed",
+                    {
+                        "job_id": req.job_id,
+                        "synthesis_id": req.synthesis_id,
+                        "reason": "job_not_found",
+                    },
+                )
+                continue
+
+            text = self.reasoning_model.synthesize(job, req.placeholder)
+            with self._lock:
+                record.status = "done"
+                record.text = text
+            result = SynthesisResult(
+                job_id=req.job_id,
+                synthesis_id=req.synthesis_id,
+                text=text,
+            )
+            results.append(result)
+            self._emit(
+                req.job_id,
+                "status_synthesis",
+                {
+                    "job_id": req.job_id,
+                    "synthesis_id": req.synthesis_id,
+                    "text": text,
+                },
+            )
+        return results
+
+    # ---- iter (debug / introspection) --------------------------------------
+
+    def iter_pending(self) -> Iterator[SynthesisRequest]:
+        with self._lock:
+            return iter([e.request for e in self._pending.values()])
+
+
+def status_c(
+    job: Any,
+    coordinator: StatusCCoordinator,
+    *,
+    ram_sampler: Callable[[], RamReading] | None = None,
+    now: Callable[[], float] | None = None,
+) -> dict[str, Any]:
+    """Mode C entry point: instant placeholder + queued synthesis.
+
+    Returns the mode-A snapshot as ``placeholder`` and a correlator
+    ``synthesis_id``. The synthesized narrative is produced
+    asynchronously by ``coordinator`` at the scheduler's next safe swap
+    point and streamed to subscribers.
+    """
+    placeholder = snapshot(job, ram_sampler=ram_sampler, now=now)
+    request = coordinator.request_status_synthesis(placeholder.job_id, placeholder)
+    return {
+        "status": "queued",
+        "placeholder": placeholder.to_dict(),
+        "synthesis_id": request.synthesis_id,
+    }

--- a/tests/runtime/test_status_mode_c.py
+++ b/tests/runtime/test_status_mode_c.py
@@ -1,0 +1,270 @@
+"""Tests for :mod:`orchestrator.runtime.status_c` (status mode C)."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from orchestrator.runtime.status import RamReading, Snapshot
+from orchestrator.runtime.status_c import (
+    StatusCCoordinator,
+    SynthesisRequest,
+    SynthesisResult,
+    status_c,
+)
+
+
+def _ram() -> RamReading:
+    return RamReading(used_mb=1.0, available_mb=2.0, total_mb=3.0)
+
+
+@dataclass
+class _FakeJob:
+    id: str = "j1"
+    status: Any = "running"
+    steps: list[Any] = field(default_factory=list)
+    events: list[Any] = field(default_factory=list)
+    model: str | None = "gpt-x"
+    total_steps: int | None = 2
+    started_at: float | None = None
+
+
+class _FakeReasoning:
+    def __init__(self, text: str = "narrative") -> None:
+        self.text = text
+        self.calls: list[tuple[Any, Snapshot]] = []
+
+    def synthesize(self, job: Any, snap: Snapshot) -> str:
+        self.calls.append((job, snap))
+        return f"{self.text}:{snap.job_id}"
+
+
+def _ids() -> Any:
+    counter = iter(("sid-1", "sid-2", "sid-3", "sid-4"))
+    return lambda: next(counter)
+
+
+def _make_coord(text: str = "narrative") -> tuple[StatusCCoordinator, _FakeReasoning]:
+    rm = _FakeReasoning(text)
+    return StatusCCoordinator(reasoning_model=rm, id_factory=_ids()), rm
+
+
+# --- public contract -------------------------------------------------------
+
+
+def test_status_c_returns_immediately_with_queued_payload() -> None:
+    coord, _ = _make_coord()
+    job = _FakeJob(steps=[{"name": "plan"}])
+    out = status_c(job, coord, ram_sampler=_ram, now=lambda: 1.0)
+
+    assert out["status"] == "queued"
+    assert out["synthesis_id"] == "sid-1"
+    placeholder = out["placeholder"]
+    assert placeholder["job_id"] == "j1"
+    assert placeholder["phase"] == "running"
+    assert placeholder["current_step"] == "plan"
+    # Reasoning model not invoked yet.
+    assert coord.pending_for("j1") is not None
+
+
+def test_status_c_returns_in_under_200ms_even_under_load() -> None:
+    coord, _ = _make_coord()
+    job = _FakeJob(steps=[{"name": f"s{i}"} for i in range(50)], total_steps=100)
+    t0 = time.perf_counter()
+    out = status_c(job, coord, ram_sampler=_ram, now=lambda: 0.0)
+    elapsed = (time.perf_counter() - t0) * 1000
+    assert out["status"] == "queued"
+    assert elapsed < 200.0
+
+
+# --- queueing & coalescing -------------------------------------------------
+
+
+def test_request_status_synthesis_enqueues_and_persists_record() -> None:
+    coord, _ = _make_coord()
+    snap = Snapshot("j1", "running", None, 0, None, 0.0, None, 0.0, 0.0, 0.0, None, 0.0)
+    req = coord.request_status_synthesis("j1", snap)
+
+    assert isinstance(req, SynthesisRequest)
+    assert req.synthesis_id == "sid-1"
+    assert len(coord) == 1
+    record = coord.get_record("sid-1")
+    assert record is not None
+    assert record.status == "queued"
+    assert record.placeholder is snap
+    assert list(coord.iter_pending()) == [req]
+
+
+def test_coalesce_returns_existing_request_for_same_job() -> None:
+    coord, _ = _make_coord()
+    snap = Snapshot("j1", "running", None, 0, None, 0.0, None, 0.0, 0.0, 0.0, None, 0.0)
+    first = coord.request_status_synthesis("j1", snap)
+    second = coord.request_status_synthesis("j1", snap)
+
+    assert first is second
+    assert len(coord) == 1
+    # status_c on same job also coalesces
+    job = _FakeJob(id="j1")
+    out = status_c(job, coord, ram_sampler=_ram, now=lambda: 0.0)
+    assert out["synthesis_id"] == first.synthesis_id
+    assert len(coord) == 1
+
+
+def test_distinct_jobs_get_distinct_synthesis_ids() -> None:
+    coord, _ = _make_coord()
+    out1 = status_c(_FakeJob(id="a"), coord, ram_sampler=_ram, now=lambda: 0.0)
+    out2 = status_c(_FakeJob(id="b"), coord, ram_sampler=_ram, now=lambda: 0.0)
+    assert out1["synthesis_id"] != out2["synthesis_id"]
+    assert len(coord) == 2
+
+
+def test_get_record_returns_none_for_unknown_id() -> None:
+    coord, _ = _make_coord()
+    assert coord.get_record("nope") is None
+    assert coord.pending_for("ghost") is None
+
+
+# --- drain / SSE -----------------------------------------------------------
+
+
+def test_drain_runs_reasoning_emits_sse_and_persists_result() -> None:
+    coord, rm = _make_coord("syn")
+    job = _FakeJob(id="j1", steps=[{"name": "plan"}])
+    out = status_c(job, coord, ram_sampler=_ram, now=lambda: 0.0)
+    sid = out["synthesis_id"]
+
+    received: list[tuple[str, dict[str, Any]]] = []
+    coord.subscribe("j1", lambda evt, payload: received.append((evt, payload)))
+
+    results = coord.drain_post_checkpoint_hooks(lambda jid: job if jid == "j1" else None)
+
+    assert results == [SynthesisResult(job_id="j1", synthesis_id=sid, text="syn:j1")]
+    assert len(rm.calls) == 1
+    record = coord.get_record(sid)
+    assert record is not None
+    assert record.status == "done"
+    assert record.text == "syn:j1"
+    assert len(coord) == 0
+    assert received == [
+        ("status_synthesis", {"job_id": "j1", "synthesis_id": sid, "text": "syn:j1"}),
+    ]
+
+
+def test_drain_marks_failed_and_emits_event_when_job_missing() -> None:
+    coord, rm = _make_coord()
+    snap = Snapshot("ghost", "running", None, 0, None, 0.0, None, 0.0, 0.0, 0.0, None, 0.0)
+    req = coord.request_status_synthesis("ghost", snap)
+
+    received: list[tuple[str, dict[str, Any]]] = []
+    coord.subscribe("ghost", lambda evt, payload: received.append((evt, payload)))
+
+    def lookup(_: str) -> Any:
+        raise KeyError("ghost")
+
+    results = coord.drain_post_checkpoint_hooks(lookup)
+
+    assert results == []
+    assert rm.calls == []
+    record = coord.get_record(req.synthesis_id)
+    assert record is not None
+    assert record.status == "failed"
+    assert received[0][0] == "status_synthesis_failed"
+    assert received[0][1]["reason"] == "job_not_found"
+
+
+def test_drain_with_returning_none_also_marks_failed() -> None:
+    coord, rm = _make_coord()
+    snap = Snapshot("j1", "running", None, 0, None, 0.0, None, 0.0, 0.0, 0.0, None, 0.0)
+    coord.request_status_synthesis("j1", snap)
+    results = coord.drain_post_checkpoint_hooks(lambda _jid: None)
+    assert results == []
+    assert rm.calls == []
+
+
+def test_drain_is_idempotent_when_queue_empty() -> None:
+    coord, _ = _make_coord()
+    assert coord.drain_post_checkpoint_hooks(lambda _: _FakeJob()) == []
+
+
+def test_unsubscribe_stops_delivery_and_is_safe_to_call_twice() -> None:
+    coord, _ = _make_coord()
+    job = _FakeJob(id="j1")
+    received: list[tuple[str, dict[str, Any]]] = []
+    unsub = coord.subscribe("j1", lambda evt, p: received.append((evt, p)))
+    unsub()
+    unsub()  # second call is a no-op
+    status_c(job, coord, ram_sampler=_ram, now=lambda: 0.0)
+    coord.drain_post_checkpoint_hooks(lambda _: job)
+    assert received == []
+
+
+def test_unsubscribe_unknown_sink_is_noop() -> None:
+    coord, _ = _make_coord()
+
+    def sink(_evt: str, _p: dict[str, Any]) -> None:
+        return None
+
+    unsub = coord.subscribe("j1", sink)
+    # Manually clear subscribers then call unsub: should not raise.
+    coord._subscribers.clear()
+    unsub()
+
+
+def test_multiple_subscribers_all_notified() -> None:
+    coord, _ = _make_coord()
+    job = _FakeJob(id="j1")
+    a: list[Any] = []
+    b: list[Any] = []
+    coord.subscribe("j1", lambda evt, p: a.append((evt, p)))
+    coord.subscribe("j1", lambda evt, p: b.append((evt, p)))
+    status_c(job, coord, ram_sampler=_ram, now=lambda: 0.0)
+    coord.drain_post_checkpoint_hooks(lambda _: job)
+    assert len(a) == 1 and len(b) == 1
+
+
+def test_drain_processes_multiple_jobs_in_fifo_order() -> None:
+    coord, rm = _make_coord("n")
+    job_a = _FakeJob(id="a")
+    job_b = _FakeJob(id="b")
+    status_c(job_a, coord, ram_sampler=_ram, now=lambda: 0.0)
+    status_c(job_b, coord, ram_sampler=_ram, now=lambda: 0.0)
+    lookup = {"a": job_a, "b": job_b}
+    results = coord.drain_post_checkpoint_hooks(lambda jid: lookup[jid])
+    assert [r.job_id for r in results] == ["a", "b"]
+    assert [c[0].id for c in rm.calls] == ["a", "b"]
+
+
+# --- defaults --------------------------------------------------------------
+
+
+def test_default_id_factory_produces_unique_hex_ids() -> None:
+    coord = StatusCCoordinator(reasoning_model=_FakeReasoning())
+    snap = Snapshot("j1", "running", None, 0, None, 0.0, None, 0.0, 0.0, 0.0, None, 0.0)
+    snap2 = Snapshot("j2", "running", None, 0, None, 0.0, None, 0.0, 0.0, 0.0, None, 0.0)
+    a = coord.request_status_synthesis("j1", snap)
+    b = coord.request_status_synthesis("j2", snap2)
+    assert a.synthesis_id != b.synthesis_id
+    assert len(a.synthesis_id) == 32  # uuid4().hex
+    assert len(b.synthesis_id) == 32
+
+
+def test_status_c_uses_default_clock_and_ram_sampler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from orchestrator.runtime import status as status_mod
+
+    class _VM:
+        used = 1024 * 1024 * 10
+        available = 1024 * 1024 * 20
+        total = 1024 * 1024 * 30
+
+    monkeypatch.setattr(status_mod.psutil, "virtual_memory", lambda: _VM())
+    monkeypatch.setattr(status_mod.time, "time", lambda: 42.0)
+
+    coord, _ = _make_coord()
+    out = status_c(_FakeJob(id="j1"), coord)
+    assert out["placeholder"]["captured_at"] == 42.0
+    assert out["placeholder"]["ram_total_mb"] == 30.0


### PR DESCRIPTION
Closes #16

Implements status mode C: queued reasoning synthesis at next checkpoint.

## Acceptance Criteria met

- `status_c(job, coordinator)` returns immediately with `{status: queued, placeholder: <mode A snapshot>, synthesis_id: <hex>}`.
- Synthesis requests are enqueued through `StatusCCoordinator.request_status_synthesis` (single shared queue, not a side channel).
- `drain_post_checkpoint_hooks(job_lookup)` is the post-checkpoint hook the scheduler calls between coder steps; it pops queued requests, invokes the resident reasoning model, persists the result, and emits an SSE event. Synthesis never runs except via this drain, so it cannot preempt a coder step.
- Results are persisted in-process as `SynthesisRecord` (status=queued|done|failed, placeholder, text); ready to be swapped for a SQLite `synthesis` table when the storage layer lands.
- Subscribers receive `status_synthesis` (or `status_synthesis_failed`) events through `coordinator.subscribe(job_id, sink)` — designed to be plugged into the existing SSE endpoint.
- Multiple queued synthesis requests for the same `job_id` collapse to one (coalesced on enqueue, same `synthesis_id` returned).
- Tests cover: immediate-return contract, sub-200ms latency under load, queueing, coalescing across distinct/same jobs, FIFO drain, SSE delivery to multiple subscribers, unsubscribe (incl. double-unsub no-op), failure path when job lookup misses, default id/clock/RAM samplers.
- `ruff check` clean. Coverage on `status_c` = 98%, total run >= 95%.

## Scope note
Mode C is implemented self-contained in `orchestrator/runtime/status_c.py` and `tests/runtime/test_status_mode_c.py` so it can land in parallel with mode B work; the scheduler / HTTP wiring is exposed as a thin coordinator surface (`request_status_synthesis`, `drain_post_checkpoint_hooks`, `subscribe`) ready to be called from `orchestrator/core/scheduler.py` and `orchestrator/interfaces/http_api.py` in a follow-up.
