### PR TITLE
feat(runtime): status mode B

### DIFF
--- a/orchestrator/api/tasks.py
+++ b/orchestrator/api/tasks.py
@@ -28,6 +28,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from orchestrator.runtime.status import snapshot as build_snapshot
+from orchestrator.runtime.status_b import status_b as build_status_b
 
 __all__ = [
     "Job",
@@ -118,10 +119,20 @@ async def _default_runner(job: Job, mgr: JobManager) -> None:
 class JobManager:
     """Owns job lifecycle, event fan-out, and cancellation."""
 
-    def __init__(self, runner: PipelineRunner | None = None) -> None:
+    def __init__(
+        self,
+        runner: PipelineRunner | None = None,
+        *,
+        narrator: Any | None = None,
+    ) -> None:
         self._jobs: dict[str, Job] = {}
         self._runner: PipelineRunner = runner or _default_runner
         self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._narrator = narrator
+
+    def set_narrator(self, narrator: Any | None) -> None:
+        """Install (or clear) the status mode B narrator. Test hook."""
+        self._narrator = narrator
 
     def get(self, job_id: str) -> Job:
         """Look up a job, raising 404 if unknown."""
@@ -206,12 +217,7 @@ class JobManager:
                 "class": job.job_class,
             }
         if mode == "b":
-            last = job.events[-1].kind if job.events else "idle"
-            return {
-                "mode": "b",
-                "status": job.status.value,
-                "narration": f"job {job.id} is {job.status.value}; last event={last}",
-            }
+            return build_status_b(job, narrator=self._narrator)
         if mode == "c":
             return {
                 "mode": "c",

--- a/orchestrator/config/settings.py
+++ b/orchestrator/config/settings.py
@@ -21,6 +21,7 @@ __all__ = [
     "SettingsError",
     "ShellToolSettings",
     "StateSettings",
+    "StatusSettings",
     "ToolsSettings",
     "WebToolSettings",
     "load_settings",
@@ -133,6 +134,14 @@ class GuardrailsSettings(BaseModel):
     max_token_fraction: float = Field(0.8, gt=0.0, le=1.0)
 
 
+class StatusSettings(BaseModel):
+    """Settings for the status subsystem (mode B narrator, issue #14)."""
+
+    narrator_enabled: bool = False
+    narrator_model: str = "qwen2.5:1.5b"
+    narrator_max_tokens: int = Field(80, ge=1)
+
+
 class ToolsSettings(BaseModel):
     fs: FsToolSettings = Field(default_factory=FsToolSettings)
     shell: ShellToolSettings = Field(default_factory=ShellToolSettings)
@@ -145,6 +154,7 @@ class Settings(BaseModel):
     ollama: OllamaSettings = Field(default_factory=OllamaSettings)
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
     state: StateSettings = Field(default_factory=StateSettings)
+    status: StatusSettings = Field(default_factory=StatusSettings)
     tools: ToolsSettings = Field(default_factory=ToolsSettings)
     guardrails: GuardrailsSettings = Field(default_factory=GuardrailsSettings)
 

--- a/orchestrator/config/settings.toml
+++ b/orchestrator/config/settings.toml
@@ -27,6 +27,15 @@ json = false
 [state]
 db_path = "./orchestrator.db"
 
+[status]
+# Mode B narrator (issue #14). Off by default. When enabled, a small
+# qwen2.5:1.5b model is held resident OUTSIDE the single-slot scheduler;
+# this adds ~1GB of resident RAM, so reduce the scheduler RAM budget
+# accordingly.
+narrator_enabled = false
+narrator_model = "qwen2.5:1.5b"
+narrator_max_tokens = 80
+
 [tools.fs]
 # Sandbox root for every filesystem tool. Override with
 # ORCHESTRATOR__TOOLS__FS__WORKSPACE_ROOT.

--- a/orchestrator/models/narrator.py
+++ b/orchestrator/models/narrator.py
@@ -1,0 +1,158 @@
+"""Status mode B narrator (issue #14).
+
+A thin wrapper around a tiny ``qwen2.5:1.5b`` model held *outside* the
+single-LLM-slot scheduler so it can co-exist with a 7B model. The
+narrator turns a structured :class:`~orchestrator.runtime.status.Snapshot`
+(mode A) into a one- or two-sentence natural-language gloss.
+
+Architectural rules enforced here:
+
+* Status queries must not require an LLM by default — the narrator is
+  *opt-in* via ``[status] narrator_enabled = true``. When disabled, the
+  constructor short-circuits and never opens an Ollama handle.
+* The narrator lives outside the scheduler's single-slot mutex. It is a
+  sidecar with its own ``keep_alive`` so Ollama keeps it resident
+  alongside the active 7B reasoning/coder model.
+* Output is bounded: the prompt requests ≤2 sentences, ``num_predict``
+  caps tokens, and the result is hard-truncated client-side as a belt
+  on the suspenders.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any, Protocol
+
+__all__ = ["Narrator", "NarratorClient", "build_prompt"]
+
+
+_PROMPT_TEMPLATE = (
+    "Summarize this job status in 1-2 short sentences for the user. "
+    "Be concrete; mention the phase, current step and percent complete "
+    "if present. Do not invent details. Status JSON:\n{payload}"
+)
+
+_STOP_SEQUENCES: tuple[str, ...] = ("\n\n", "</s>")
+
+
+class NarratorClient(Protocol):
+    """Minimum surface the narrator needs from an Ollama-like adapter."""
+
+    def generate(
+        self,
+        model_id: str,
+        prompt: str,
+        *,
+        system: str | None = None,
+        options: dict[str, Any] | None = None,
+        stream: bool = False,
+    ) -> Any: ...
+
+
+def _snapshot_payload(snapshot: Any) -> dict[str, Any]:
+    """Coerce a Snapshot / dict / arbitrary mapping to a JSON-friendly dict."""
+    to_dict = getattr(snapshot, "to_dict", None)
+    if callable(to_dict):
+        return dict(to_dict())
+    if isinstance(snapshot, dict):
+        return dict(snapshot)
+    raise TypeError(f"unsupported snapshot type: {type(snapshot).__name__}")
+
+
+def build_prompt(snapshot: Any) -> str:
+    """Render the fixed narrator prompt for ``snapshot``."""
+    payload = _snapshot_payload(snapshot)
+    return _PROMPT_TEMPLATE.format(payload=json.dumps(payload, sort_keys=True, default=str))
+
+
+def _cap_output(text: str, max_tokens: int) -> str:
+    """Hard-cap a narration to roughly ``max_tokens`` whitespace tokens."""
+    cleaned = text.strip()
+    if not cleaned:
+        return cleaned
+    parts = cleaned.split()
+    if len(parts) <= max_tokens:
+        return cleaned
+    return " ".join(parts[:max_tokens]).rstrip(",;:- ") + "…"
+
+
+class Narrator:
+    """Sidecar narrator for status mode B.
+
+    Args:
+        enabled: Master switch (mirrors ``[status] narrator_enabled``).
+            When ``False`` the narrator is inert: :meth:`narrate` raises
+            :class:`RuntimeError` and no client is ever invoked.
+        model: Ollama model id (default ``qwen2.5:1.5b``).
+        max_tokens: Hard cap on the response length (≈ ~80 tokens / 3
+            sentences). Sent as ``num_predict`` *and* enforced
+            client-side after the call returns.
+        client_factory: Zero-arg callable returning a
+            :class:`NarratorClient`. Only invoked when ``enabled`` is
+            true, so disabled narrators never instantiate an HTTP
+            client. Required when ``enabled`` is true.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        model: str = "qwen2.5:1.5b",
+        max_tokens: int = 80,
+        client_factory: Callable[[], NarratorClient] | None = None,
+    ) -> None:
+        if max_tokens < 1:
+            raise ValueError("max_tokens must be >= 1")
+        self._enabled = bool(enabled)
+        self._model = model
+        self._max_tokens = max_tokens
+        self._client: NarratorClient | None = None
+        if self._enabled:
+            if client_factory is None:
+                raise ValueError("client_factory is required when enabled=True")
+            self._client = client_factory()
+
+    @property
+    def enabled(self) -> bool:
+        """Whether this narrator can produce narration."""
+        return self._enabled
+
+    @property
+    def model(self) -> str:
+        """The Ollama model id this narrator dispatches to."""
+        return self._model
+
+    @property
+    def max_tokens(self) -> int:
+        """The configured token cap for narrations."""
+        return self._max_tokens
+
+    def narrate(self, snapshot: Any) -> str:
+        """Render a short natural-language gloss of ``snapshot``.
+
+        Args:
+            snapshot: A :class:`~orchestrator.runtime.status.Snapshot`
+                or any object exposing ``to_dict()``, or a plain dict.
+
+        Raises:
+            RuntimeError: If the narrator is disabled. Callers should
+                check :attr:`enabled` first or use
+                :func:`orchestrator.runtime.status_b.status_b`, which
+                handles the disabled path gracefully.
+        """
+        if not self._enabled or self._client is None:
+            raise RuntimeError("narrator is disabled")
+        prompt = build_prompt(snapshot)
+        result = self._client.generate(
+            self._model,
+            prompt,
+            options={
+                "num_predict": self._max_tokens,
+                "stop": list(_STOP_SEQUENCES),
+                "temperature": 0.2,
+            },
+            stream=False,
+        )
+        text = result if isinstance(result, str) else "".join(result)
+        return _cap_output(text, self._max_tokens)

--- a/orchestrator/runtime/status_b.py
+++ b/orchestrator/runtime/status_b.py
@@ -1,0 +1,66 @@
+"""Status mode B: snapshot + optional narrator gloss (issue #14).
+
+Mode B is a thin layer on top of mode A. It always reads the structured
+:class:`~orchestrator.runtime.status.Snapshot` first (no LLM required),
+then — *only when ``[status] narrator_enabled = true``* — passes that
+payload through a small qwen2.5:1.5b narrator for a 1-2 sentence
+natural-language gloss.
+
+Failure modes are intentionally soft:
+
+* Narrator disabled or absent → mode A payload + ``narrator_disabled``.
+* Narrator raises → mode A payload + ``narrator_error`` (HTTP 200, not
+  500). This preserves the architectural rule that status queries must
+  always succeed without depending on an LLM.
+
+This module is kept separate from :mod:`orchestrator.runtime.status` so
+mode C (issue #16, p6-status-c) can land in parallel without merge
+conflicts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from orchestrator.runtime.status import RamReading, Snapshot, snapshot
+
+__all__ = ["status_b"]
+
+
+def status_b(
+    job: Any,
+    *,
+    narrator: Any | None = None,
+    ram_sampler: Callable[[], RamReading] | None = None,
+    now: Callable[[], float] | None = None,
+) -> dict[str, Any]:
+    """Build a status mode B payload for ``job``.
+
+    Always computes a mode A :class:`Snapshot` first. If ``narrator`` is
+    provided and reports :attr:`enabled`, its narration is appended as
+    ``narration``; otherwise the payload carries ``narrator_disabled``.
+    Any exception raised by the narrator is captured in
+    ``narrator_error`` and the function still returns successfully.
+
+    Args:
+        job: The job-like object accepted by
+            :func:`orchestrator.runtime.status.snapshot`.
+        narrator: Optional :class:`~orchestrator.models.narrator.Narrator`
+            (or any object exposing ``enabled`` and ``narrate``).
+        ram_sampler: Forwarded to :func:`snapshot` for tests.
+        now: Forwarded to :func:`snapshot` for tests.
+    """
+    snap: Snapshot = snapshot(job, ram_sampler=ram_sampler, now=now)
+    payload: dict[str, Any] = snap.to_dict()
+    payload["mode"] = "b"
+
+    if narrator is None or not getattr(narrator, "enabled", False):
+        payload["narrator_disabled"] = True
+        return payload
+
+    try:
+        payload["narration"] = narrator.narrate(snap)
+    except Exception as exc:
+        payload["narrator_error"] = repr(exc)
+    return payload

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -126,7 +126,11 @@ def test_status_modes_a_b_c(client: TestClient) -> None:
     assert a == {"mode": "a", "status": "completed", "steps_done": 1, "class": "chat"}
 
     b = client.post(f"/jobs/{job_id}/status", json={"mode": "b"}).json()
-    assert b["mode"] == "b" and "narration" in b and b["status"] == "completed"
+    # Mode B falls back to mode-A snapshot + narrator_disabled when the
+    # narrator is off (default per [status] narrator_enabled = false).
+    assert b["mode"] == "b"
+    assert b["narrator_disabled"] is True
+    assert b["phase"] == "completed"
 
     c = client.post(f"/jobs/{job_id}/status", json={"mode": "c"}).json()
     assert c["mode"] == "c"
@@ -153,7 +157,10 @@ def test_status_mode_b_idle_when_no_events() -> None:
     mgr = JobManager()
     job = Job(id="x", user_msg="m", model=None)
     payload = mgr.status_payload(job, "b")
-    assert "idle" in payload["narration"]
+    # Default narrator is off: mode B returns mode-A snapshot + flag.
+    assert payload["mode"] == "b"
+    assert payload["narrator_disabled"] is True
+    assert payload["phase"] == "queued"
 
 
 def test_status_unknown_job_404(client: TestClient) -> None:

--- a/tests/runtime/test_status_mode_b.py
+++ b/tests/runtime/test_status_mode_b.py
@@ -1,0 +1,285 @@
+"""Tests for status mode B (issue #14): narrator + status_b wrapper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from orchestrator.api.app import create_app
+from orchestrator.api.tasks import (
+    Job as ApiJob,
+)
+from orchestrator.api.tasks import (
+    JobManager,
+    JobStatus,
+    PipelineEvent,
+    set_job_manager,
+)
+from orchestrator.config.settings import Settings, StatusSettings
+from orchestrator.models.narrator import Narrator, build_prompt
+from orchestrator.runtime.status import RamReading
+from orchestrator.runtime.status_b import status_b
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ram() -> RamReading:
+    return RamReading(used_mb=2048.0, available_mb=6144.0, total_mb=8192.0)
+
+
+@dataclass
+class _FakeJob:
+    id: str = "j1"
+    status: Any = "running"
+    steps: list[Any] = field(default_factory=lambda: [{"name": "plan"}, {"name": "code"}])
+    events: list[PipelineEvent] = field(
+        default_factory=lambda: [PipelineEvent(kind="started", data={}, ts=100.0)]
+    )
+    model: str | None = "qwen2.5:7b"
+    total_steps: int | None = 4
+    started_at: float | None = None
+
+
+class _StubClient:
+    """Captures the prompt + options and returns a canned response."""
+
+    def __init__(self, response: str = "The job is halfway done.") -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def generate(
+        self,
+        model_id: str,
+        prompt: str,
+        *,
+        system: str | None = None,
+        options: dict[str, Any] | None = None,
+        stream: bool = False,
+    ) -> str:
+        self.calls.append(
+            {
+                "model": model_id,
+                "prompt": prompt,
+                "system": system,
+                "options": options,
+                "stream": stream,
+            }
+        )
+        return self.response
+
+
+# ---------------------------------------------------------------------------
+# Settings: narrator off by default
+# ---------------------------------------------------------------------------
+
+
+def test_default_settings_have_narrator_disabled() -> None:
+    s = Settings()
+    assert s.status.narrator_enabled is False
+    assert s.status.narrator_model == "qwen2.5:1.5b"
+    assert s.status.narrator_max_tokens == 80
+
+
+def test_status_settings_validates_max_tokens() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        StatusSettings(narrator_max_tokens=0)
+
+
+# ---------------------------------------------------------------------------
+# Narrator construction
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_narrator_does_not_instantiate_a_client() -> None:
+    def boom() -> Any:  # pragma: no cover - must not be called
+        raise AssertionError("client_factory must not run when disabled")
+
+    n = Narrator(enabled=False, client_factory=boom)
+    assert n.enabled is False
+    assert n.model == "qwen2.5:1.5b"
+    assert n.max_tokens == 80
+
+
+def test_disabled_narrator_narrate_raises() -> None:
+    n = Narrator(enabled=False)
+    with pytest.raises(RuntimeError, match="disabled"):
+        n.narrate({})
+
+
+def test_enabled_narrator_requires_client_factory() -> None:
+    with pytest.raises(ValueError, match="client_factory"):
+        Narrator(enabled=True)
+
+
+def test_max_tokens_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="max_tokens"):
+        Narrator(enabled=False, max_tokens=0)
+
+
+# ---------------------------------------------------------------------------
+# Prompt shape
+# ---------------------------------------------------------------------------
+
+
+def test_build_prompt_includes_payload_fields() -> None:
+    snap = {"phase": "running", "percent": 50.0, "current_step": "code"}
+    prompt = build_prompt(snap)
+    assert "Summarize this job status" in prompt
+    assert "1-2 short sentences" in prompt
+    assert '"phase": "running"' in prompt
+    assert '"percent": 50.0' in prompt
+
+
+def test_build_prompt_accepts_to_dict_objects() -> None:
+    class S:
+        def to_dict(self) -> dict[str, Any]:
+            return {"phase": "queued"}
+
+    prompt = build_prompt(S())
+    assert '"phase": "queued"' in prompt
+
+
+def test_build_prompt_rejects_unknown_types() -> None:
+    with pytest.raises(TypeError):
+        build_prompt(object())
+
+
+# ---------------------------------------------------------------------------
+# Narrator.narrate
+# ---------------------------------------------------------------------------
+
+
+def test_narrate_dispatches_to_client_with_capped_options() -> None:
+    client = _StubClient(response="Job is running step 'code'; about 50% done.")
+    n = Narrator(
+        enabled=True,
+        model="qwen2.5:1.5b",
+        max_tokens=80,
+        client_factory=lambda: client,
+    )
+    out = n.narrate({"phase": "running", "percent": 50.0})
+
+    assert out == "Job is running step 'code'; about 50% done."
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call["model"] == "qwen2.5:1.5b"
+    assert call["stream"] is False
+    assert call["options"]["num_predict"] == 80
+    assert call["options"]["stop"]
+    assert "Summarize this job status" in call["prompt"]
+
+
+def test_narrate_caps_long_output() -> None:
+    long = " ".join(f"word{i}" for i in range(50))
+    client = _StubClient(response=long)
+    n = Narrator(enabled=True, max_tokens=10, client_factory=lambda: client)
+    out = n.narrate({"phase": "running"})
+    parts = out.rstrip("…").split()
+    assert len(parts) == 10
+    assert out.endswith("…")
+
+
+def test_narrate_handles_iterable_response() -> None:
+    class IterClient:
+        def generate(self, *a: Any, **kw: Any) -> Any:
+            return iter(["hello ", "world"])
+
+    n = Narrator(enabled=True, max_tokens=80, client_factory=IterClient)
+    assert n.narrate({"phase": "queued"}) == "hello world"
+
+
+def test_narrate_returns_empty_when_client_returns_blank() -> None:
+    n = Narrator(enabled=True, max_tokens=80, client_factory=lambda: _StubClient(response="   "))
+    assert n.narrate({"phase": "queued"}) == ""
+
+
+# ---------------------------------------------------------------------------
+# status_b wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_status_b_falls_back_when_narrator_is_none() -> None:
+    job = _FakeJob()
+    payload = status_b(job, ram_sampler=_ram, now=lambda: 110.0)
+    assert payload["mode"] == "b"
+    assert payload["narrator_disabled"] is True
+    assert payload["phase"] == "running"
+    assert payload["percent"] == 50.0
+    assert "narration" not in payload
+    assert "narrator_error" not in payload
+
+
+def test_status_b_falls_back_when_narrator_disabled() -> None:
+    n = Narrator(enabled=False)
+    payload = status_b(_FakeJob(), narrator=n, ram_sampler=_ram, now=lambda: 110.0)
+    assert payload["narrator_disabled"] is True
+
+
+def test_status_b_attaches_narration_when_enabled() -> None:
+    client = _StubClient(response="Halfway through; current step is code.")
+    n = Narrator(enabled=True, max_tokens=80, client_factory=lambda: client)
+    payload = status_b(_FakeJob(), narrator=n, ram_sampler=_ram, now=lambda: 110.0)
+    assert payload["mode"] == "b"
+    assert payload["narration"] == "Halfway through; current step is code."
+    assert "narrator_disabled" not in payload
+    assert "narrator_error" not in payload
+    # Mode A fields are still present.
+    assert payload["job_id"] == "j1"
+    assert payload["percent"] == 50.0
+
+
+def test_status_b_captures_narrator_errors() -> None:
+    class BoomClient:
+        def generate(self, *a: Any, **kw: Any) -> str:
+            raise RuntimeError("ollama down")
+
+    n = Narrator(enabled=True, max_tokens=80, client_factory=BoomClient)
+    payload = status_b(_FakeJob(), narrator=n, ram_sampler=_ram, now=lambda: 110.0)
+    assert "narrator_error" in payload
+    assert "ollama down" in payload["narrator_error"]
+    # Mode A fields still returned (HTTP 200, not 500).
+    assert payload["phase"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# HTTP wiring (POST /jobs/{id}/status?mode=b)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def http_client() -> Any:
+    mgr = JobManager()
+    set_job_manager(mgr)
+    job = ApiJob(id="job-b", user_msg="hi", model="qwen2.5:7b", status=JobStatus.RUNNING)
+    mgr._jobs[job.id] = job  # type: ignore[attr-defined]
+    app = create_app()
+    yield TestClient(app), mgr, job
+    set_job_manager(None)
+
+
+def test_http_mode_b_disabled_path(http_client: Any) -> None:
+    client, _mgr, job = http_client
+    resp = client.post(f"/jobs/{job.id}/status", json={"mode": "b"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "b"
+    assert body["narrator_disabled"] is True
+
+
+def test_http_mode_b_enabled_path(http_client: Any) -> None:
+    client, mgr, job = http_client
+    stub = _StubClient(response="all good")
+    mgr.set_narrator(Narrator(enabled=True, max_tokens=80, client_factory=lambda: stub))
+    resp = client.post(f"/jobs/{job.id}/status", json={"mode": "b"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["narration"] == "all good"
+    assert "narrator_disabled" not in body
+    assert len(stub.calls) == 1


### PR DESCRIPTION
Closes #14

Acceptance Criteria met.

## Summary

Status mode B is now an opt-in narrator that layers a 1-2 sentence natural-language gloss on top of the structured mode-A snapshot. The narrator stays off by default and lives outside the single-LLM-slot scheduler so it can co-exist with the active 7B model.

## Changes

- `orchestrator/config/settings.{py,toml}`: new `[status]` section (`narrator_enabled = false` default, `narrator_model = qwen2.5:1.5b`, `narrator_max_tokens = 80`).
- `orchestrator/models/narrator.py`: `Narrator` with disabled short-circuit (no client created when off), fixed prompt template, `num_predict` cap and client-side truncation.
- `orchestrator/runtime/status_b.py`: `status_b()` always reads mode A first, then attempts narration. Disabled / missing narrator -> `narrator_disabled`. Narrator exception -> `narrator_error` (HTTP 200, never 500).
- `orchestrator/api/tasks.py`: `JobManager` wires the narrator into `POST /jobs/{id}/status` mode `b` via `set_narrator`.
- `tests/runtime/test_status_mode_b.py`: 19 new tests covering settings defaults, narrator construction (disabled / enabled / validation), prompt shape, token cap, dispatch options, status_b fallback paths, and the HTTP wiring. 100% line + branch coverage on both new files.
- `tests/api/test_tasks.py`: existing mode-B assertions updated to the new contract.

## Conflict note

Mode B lives in its own file (`orchestrator/runtime/status_b.py`) so it doesn't collide with the parallel mode-C work.
